### PR TITLE
Fix border color of input elements

### DIFF
--- a/static/sass/_hgse.scss
+++ b/static/sass/_hgse.scss
@@ -28,6 +28,7 @@ $secondary-25: lighten($secondary, 20%); //Important Heading BG Color
 //Gray Color Variables
 $gray: #3f3f3f; //Main Text Color
 $gray-75: lighten($gray, 18.25%); //Lighter Text Color
+$gray-50: lighten($gray, 40%); //Lighter Border Color
 
 $gray-3: #e9e9e9; //Block/Course BG Color
 $gray-2: #f2f2f2;
@@ -220,5 +221,18 @@ body .window-wrap header .left.nav-global {
 
         text-transform: none;
         color: $gray-2 !important;
+    }
+}
+//--------------------
+//  Specific Overrides
+//--------------------
+
+body {
+    // Use a darker gray for the border of controls
+    textarea,
+    input[type="text"],
+    input[type="email"],
+    input[type="password"] {
+      border: 1px solid $gray-50;
     }
 }


### PR DESCRIPTION
The border color of `<textarea>` elements in the HGSE theme is too light. This is one of two suggested ways of fixing it.
- [Current HGSE Theme](https://cloud.githubusercontent.com/assets/945577/9482628/d4778e4e-4b4a-11e5-98c6-757ac9be2942.png) - this shows the problem
- [Normal edX styling](https://cloud.githubusercontent.com/assets/945577/9482639/f2854304-4b4a-11e5-8bb6-8661c180551b.png)
- [Override control borders only](https://cloud.githubusercontent.com/assets/945577/9482647/01f6e0fe-4b4b-11e5-8973-e50bbb405c83.png) <- **this PR**
- [Alternative fix: use default edX border colors](https://cloud.githubusercontent.com/assets/945577/9482668/2621d27c-4b4b-11e5-9d57-2c69d0b28e47.png) - code [here](https://github.com/open-craft/edx-theme/commit/e53d723828633d638ebb53ad95ee03fd10144e3a). I think this looks best but it's a bigger change.

Test instructions: clone this repo into the `themes` folder of your devstack (it's on your host, in the same folder as `edx-platform` and the `Vagrantfile`). Check out this branch. Edit the `lms.envs.json` file  and set `USE_CUSTOM_THEME` to true, and `THEME_NAME` to `hgse`. 
