### PR TITLE
Use default edX border colors

### DIFF
--- a/static/sass/_hgse.scss
+++ b/static/sass/_hgse.scss
@@ -144,12 +144,12 @@ $action-secondary-active-focused-shadow: none;
 $action-secondary-disabled-bg: $gray-3;
 $action-secondary-disabled-fg: $gray;
 
-//
+// Use the default border colors:
 
-$border-color-1: $main-bg-60;
-$border-color-2: $main-bg-60;
-$border-color-3: $main-bg-60;
-$outer-border-color: $main-bg-60;
+//$border-color-1: $main-bg-60;
+//$border-color-2: $gray-75;
+//$border-color-3: $main-bg-60;
+//$outer-border-color: $main-bg-60;
 
 $sidebar-color: $gray-1;
 


### PR DESCRIPTION
The border color of `<textarea>` elements in the HGSE theme is too light. This is one of two suggested ways of fixing it.
- [Current HGSE Theme](https://cloud.githubusercontent.com/assets/945577/9482628/d4778e4e-4b4a-11e5-98c6-757ac9be2942.png) - this shows the problem
- [Normal edX styling](https://cloud.githubusercontent.com/assets/945577/9482639/f2854304-4b4a-11e5-8bb6-8661c180551b.png)
- [Fix: use default edX border colors](https://cloud.githubusercontent.com/assets/945577/9482668/2621d27c-4b4b-11e5-9d57-2c69d0b28e47.png) - code [here](https://github.com/open-craft/edx-theme/commit/e53d723828633d638ebb53ad95ee03fd10144e3a) <- **this PR**

Test instructions: clone this repo into the `themes` folder of your devstack (it's on your host, in the same folder as `edx-platform` and the `Vagrantfile`). Rename the `edx-theme` folder to `hgse`. Check out this branch. Edit the `lms.envs.json` file  and set `USE_CUSTOM_THEME` to true, and `THEME_NAME` to `hgse`. 
