### PR TITLE
Hide PearsonX featured programs container

### DIFF
--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -29,6 +29,9 @@ from openedx.core.djangolib.markup import HTML, Text
         </div>
       </div>
     </header>
+
+<!-- Indefinitely hide the featured programs container
+
     <div class="programs-container">
       <div class="program-container">
         <a href="/courses">
@@ -41,6 +44,9 @@ from openedx.core.djangolib.markup import HTML, Text
         </a>
       </div>
     </div>
+
+-->
+
   <div class="offered-by-box">
     <h2>
       Offered by Pearson and edX in conjunction with University of Pennsylvania’s Wharton School, Columbia, Thunderbird, and TU Delft


### PR DESCRIPTION
Testing instructions: Verify that the appearance of the theme on the Open edX instance at https://pearsonx-theme.opencraft.hosting/ matches the appearance of the "after" screenshot, and that using in-browser developer tools to remove the newly-added comment tags surrounding the code matches the appearance of the "before" screenshot.

Screenshot (before):

<img width="1281" alt="screen shot 2017-08-29 at 1 55 24 pm" src="https://user-images.githubusercontent.com/7773758/29836030-d96d3f7e-8cc1-11e7-8e1f-1aa1340ba331.png">

Screenshot (after):

<img width="1239" alt="screen shot 2017-08-29 at 1 54 48 pm" src="https://user-images.githubusercontent.com/7773758/29836051-e84e04ec-8cc1-11e7-9683-539008ef37c7.png">
