### PR TITLE
Backport advertised start date change; hide enrollment button when advertised start date is set

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -7,6 +7,7 @@ from django.conf import settings
 from edxmako.shortcuts import marketing_link
 from openedx.core.lib.courses import course_image_url
 from xmodule.contentstore.content import StaticContent
+from six import string_types
 %>
 
 <%inherit file="../main.html" />
@@ -194,9 +195,11 @@ from xmodule.contentstore.content import StaticContent
               href_class = "register"
           %>
           <div class="inquire-wrapper">
+            % if not course.advertised_start:
             <a href="${reg_href}" class="${href_class}">
               ${_("Enroll Now")}
             </a>
+            % endif
             <a href="/contact#00N61000002EYUJ=${course.display_name_with_default_escaped}" class="inquire">
               ${_("Inquire Now")}
             </a>
@@ -209,12 +212,12 @@ from xmodule.contentstore.content import StaticContent
             <li class="important-dates-item"><span class="icon fa fa-info-circle" aria-hidden="true"></span><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default | h}</span></li>
             % if not course.start_date_is_still_default:
                 <%
-                    course_start_date = course.start
+                    course_start_date = course.advertised_start or course.start
                 %>
               <li class="important-dates-item">
                 <span class="icon fa fa-calendar" aria-hidden="true"></span>
                 <p class="important-dates-item-title">${_("Classes Start")}</p>
-                % if isinstance(course_start_date, str):
+                % if isinstance(course_start_date, string_types):
                     <span class="important-dates-item-text start-date">${course_start_date}</span>
                 % else:
                     <%


### PR DESCRIPTION
See edx/edx-platform#15921 for information about advertised start date in context of sidebar.

Additional point specific to this theme: Note that when an advertised start date is set, the Enroll Now button is hidden, as in the below screenshot.

Screenshot (no advertised start date):

<img width="1225" alt="screen shot 2017-08-29 at 4 22 52 pm" src="https://user-images.githubusercontent.com/7773758/29842491-156ee508-8cd7-11e7-81a0-385f0239debd.png">

Screenshot (advertised start date):

<img width="1219" alt="screen shot 2017-08-29 at 4 21 38 pm" src="https://user-images.githubusercontent.com/7773758/29842515-28ccaac2-8cd7-11e7-8cce-71811e5245c8.png">
