### PR TITLE
SalesForce form validation; submission success banner

### DIFF
--- a/lms/static/sass/_pearsonx.scss
+++ b/lms/static/sass/_pearsonx.scss
@@ -231,6 +231,13 @@ h2 {
           background: #1790c7;
         }
       }
+      #error-message{
+        display: none;
+        background-color: $error-color;
+        color: $white;
+        margin-bottom: (0.5 * $baseline);
+        padding: (0.25 * $baseline);
+      }
     }
   }
 }
@@ -456,6 +463,168 @@ section.course-info {
           }
         }
       }
+    }
+  }
+}
+
+/*
+The below section is backported from Ginkgo to apply theming to the
+banner indicating that the inquiry form was submitted successfully.
+It should be removed when upgrading the theme to Ginkgo; test to make
+sure that the inquiry success banner still appears correctly.
+*/
+
+.wrapper-msg {
+  display: block;
+  background: $notify-banner-bg-1;
+  padding: $baseline ($baseline*1.5);
+
+  // basic object
+  .msg {
+    @include clearfix();
+    max-width: grid-width(12);
+    min-width: 760px;
+    width: flex-grid(12);
+    margin: 0 auto;
+  }
+
+  .msg-content,
+  .msg-icon {
+    display: inline-block;
+    vertical-align: middle;
+  }
+
+  .msg-content {
+
+    .title {
+      @extend %t-title5;
+      @extend %t-weight4;
+      margin-bottom: ($baseline/4);
+      color: inherit;
+      text-transform: none;
+      letter-spacing: 0;
+    }
+
+    .copy {
+      @extend %t-copy-sub1;
+      color: inherit;
+
+      p { // nasty reset
+        @extend %t-copy-sub1;
+        color: inherit;
+      }
+    }
+  }
+
+  .has-actions {
+
+    .msg-content {
+      width: flex-grid(10,12);
+    }
+
+    .nav-actions,
+    .msg-actions {
+      width: flex-grid(2,12);
+      display: inline-block;
+      vertical-align: middle;
+      text-align: right;
+
+      .action-primary {
+        @extend %btn-primary-green;
+      }
+    }
+  }
+
+  .is-dismissable {
+
+    .msg-content {
+      width: flex-grid(11,12);
+    }
+
+    .action-dismiss {
+      width: flex-grid(1,12);
+      display: inline-block;
+      vertical-align: top;
+      text-align: right;
+
+      .button-dismiss {  //ugly reset on button element
+        @extend %t-icon4;
+        background: none;
+        box-shadow: none;
+        border: none;
+        text-shadow: none;
+        color: inherit;
+
+        &:hover, &:focus {
+          color: $action-primary-bg;
+        }
+      }
+    }
+  }
+
+  // object variations
+  &.urgency-high {
+    background: $notify-banner-bg-1;
+
+    .msg {
+      color: $white;
+    }
+  }
+
+  &.urgency-mid {
+    background: $notify-banner-bg-2;
+
+    .msg {
+      color: $white;
+    }
+  }
+
+  &.urgency-low {
+    background: $notify-banner-bg-3;
+    box-shadow: 0 1px 2px $shadow;
+
+    .msg {
+      color: $black;
+    }
+  }
+
+  &.urgency-info {
+    background: $msg-bg;
+    .msg {
+      color: $white;
+    }
+    .msg-icon {
+      font-size: 2.5em;
+      padding: 20px;
+    }
+    .msg-content {
+      max-width: 80%;
+    }
+  }
+
+  &.alert {
+    border-top: 3px solid $alert-color;
+  }
+
+  &.error {
+    border-top: 3px solid $error-color;
+  }
+
+  &.warning {
+    border-top: 3px solid $warning-color;
+  }
+
+  &.success {
+    border-top: 3px solid $success-color;
+  }
+
+
+  &.is-incontext {
+    margin: $baseline;
+
+    .msg {
+      max-width: unset;
+      min-width: auto;
     }
   }
 }

--- a/lms/static/sass/_pearsonx.scss
+++ b/lms/static/sass/_pearsonx.scss
@@ -467,6 +467,10 @@ section.course-info {
   }
 }
 
+#contacted-message {
+  display: none;
+}
+
 /*
 The below section is backported from Ginkgo to apply theming to the
 banner indicating that the inquiry form was submitted successfully.

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -102,6 +102,11 @@ from six.moves.urllib.parse import quote
 
     %endif
 
+    var hashParams = window.location.hash;
+    if (hashParams.includes("contacted")) {
+      $("#contacted-message").show();
+    }
+
   })(this)
   </script>
 
@@ -111,23 +116,21 @@ from six.moves.urllib.parse import quote
 <%block name="pagetitle">${course.display_name_with_default_escaped}</%block>
 
 <section class="course-info">
-  %if 'contacted' in request.GET:
-    <div class="wrapper-msg urgency-info">
-      <div class="msg">
-        <span class="msg-icon fa fa-info-circle" aria-hidden="true"></span>
-        <div class="msg-content">
-          <h2 class="title">
-            Thank you for your inquiry into PearsonX and our program offerings. One of our Program Advisors will be contacting you shortly.
-          </h2>
-          <div class="copy">
-            <p>
-              We are committed to helping individuals advance in their careers and take the next step in their education goals. PearsonX provides you with globally recognized, relevant programs of study, as well as the opportunity to network with peers and progress your career.
-            </p>
-          </div>
+  <div class="wrapper-msg urgency-info" id="contacted-message">
+    <div class="msg">
+      <span class="msg-icon fa fa-info-circle" aria-hidden="true"></span>
+      <div class="msg-content">
+        <h2 class="title">
+          Thank you for your inquiry into PearsonX and our program offerings. One of our Program Advisors will be contacting you shortly.
+        </h2>
+        <div class="copy">
+          <p>
+            We are committed to helping individuals advance in their careers and take the next step in their education goals. PearsonX provides you with globally recognized, relevant programs of study, as well as the opportunity to network with peers and progress your career.
+          </p>
         </div>
       </div>
     </div>
-  %endif
+  </div>
   <header class="course-profile" style="background-image: url('${course_image_url(course, 'banner_image')}')">
     <div class="intro-inner-wrapper">
       <section class="intro">
@@ -218,7 +221,7 @@ from six.moves.urllib.parse import quote
               ${_("Enroll Now")}
             </a>
             % endif
-            <a href="/contact#00N61000002EYUJ=${course.display_name_with_default_escaped}&retURL=${quote(request.build_absolute_uri(request.path) + '?contacted')}" class="inquire">
+            <a href="/contact#00N61000002EYUJ=${course.display_name_with_default_escaped}&retURL=${quote(request.build_absolute_uri(request.path) + '#contacted')}" class="inquire">
               ${_("Inquire Now")}
             </a>
           </div>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -8,6 +8,7 @@ from edxmako.shortcuts import marketing_link
 from openedx.core.lib.courses import course_image_url
 from xmodule.contentstore.content import StaticContent
 from six import string_types
+from six.moves.urllib.parse import quote
 %>
 
 <%inherit file="../main.html" />
@@ -110,6 +111,23 @@ from six import string_types
 <%block name="pagetitle">${course.display_name_with_default_escaped}</%block>
 
 <section class="course-info">
+  %if 'contacted' in request.GET:
+    <div class="wrapper-msg urgency-info">
+      <div class="msg">
+        <span class="msg-icon fa fa-info-circle" aria-hidden="true"></span>
+        <div class="msg-content">
+          <h2 class="title">
+            Thank you for your inquiry into PearsonX and our program offerings. One of our Program Advisors will be contacting you shortly.
+          </h2>
+          <div class="copy">
+            <p>
+              We are committed to helping individuals advance in their careers and take the next step in their education goals. PearsonX provides you with globally recognized, relevant programs of study, as well as the opportunity to network with peers and progress your career.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  %endif
   <header class="course-profile" style="background-image: url('${course_image_url(course, 'banner_image')}')">
     <div class="intro-inner-wrapper">
       <section class="intro">
@@ -200,7 +218,7 @@ from six import string_types
               ${_("Enroll Now")}
             </a>
             % endif
-            <a href="/contact#00N61000002EYUJ=${course.display_name_with_default_escaped}" class="inquire">
+            <a href="/contact#00N61000002EYUJ=${course.display_name_with_default_escaped}&retURL=${quote(request.build_absolute_uri(request.path) + '?contacted')}" class="inquire">
               ${_("Inquire Now")}
             </a>
           </div>

--- a/lms/templates/static_templates/contact.html
+++ b/lms/templates/static_templates/contact.html
@@ -13,10 +13,10 @@
         </div>
         <div class="contact-form-container">
 
-            <form action="https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
+            <form action="https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST" id="contact-form">
 
             <input type=hidden name="oid" value="00D61000000H03y">
-            <input type=hidden name="retURL" value="${request.build_absolute_uri('/')}">
+            <input type=hidden id="retURL" name="retURL" value="${request.build_absolute_uri('/')}">
 
             <label class="hidden-label" for="first_name">First Name</label><input  id="first_name" maxlength="40" name="first_name" size="20" placeholder="First Name" /><br>
 
@@ -25,6 +25,7 @@
             <label class="hidden-label" for="email">Email</label><input  id="email" maxlength="80" name="email" size="20" placeholder="Email" /><br>
 
             <label for="00N5800000DJ2eh">Phone - Country Code</label><select id="00N5800000DJ2eh" name="00N5800000DJ2eh" title="Country Code">
+                  <option value="" selected="selected">--Select--</option>
                   <option value="93">Afghanistan (+93)</option>
                   <option value="+358-18">Aland Islands (+358-18)</option>
                   <option value="355">Albania (+355)</option>
@@ -257,7 +258,7 @@
                   <option value="380">Ukraine (+380)</option>
                   <option value="971">United Arab Emirates (+971)</option>
                   <option value="44">United Kingdom (+44)</option>
-                  <option value="1" selected="selected">United States (+1)</option>
+                  <option value="1">United States (+1)</option>
                   <option value="1">United States Minor Outlying Islands (+1)</option>
                   <option value="598">Uruguay (+598)</option>
                   <option value="998">Uzbekistan (+998)</option>
@@ -277,7 +278,7 @@
 
             <label class="hidden-label" for="00N58000008J32f">City</label><input  id="00N58000008J32f" maxlength="55" name="00N58000008J32f" size="20" placeholder="City" /><br>
 
-            <label for="00N5800000BOaSs">Country of Residence:</label><select  id="00N5800000BOaSs" name="00N5800000BOaSs" title="Country of Residence"><option value="">--None--</option><option value="Afghanistan">Afghanistan</option>
+            <label for="00N5800000BOaSs">Country of Residence:</label><select  id="00N5800000BOaSs" name="00N5800000BOaSs" title="Country of Residence"><option value="" selected="selected">--Select--</option><option value="Afghanistan">Afghanistan</option>
             <option value="Albania">Albania</option>
             <option value="Algeria">Algeria</option>
             <option value="Andorra">Andorra</option>
@@ -542,6 +543,9 @@
                   <option value="Blank">Blank</option>
                 </select><br>
             </div>
+            <div id="error-message">
+                All fields are required in order to submit this form.
+            </div>
             <button class="contact-submit-button" type="submit" name="submit">Request information</button>
 
             </form>
@@ -553,6 +557,16 @@
                 var p = hashParams[i].split('=');
                 $("#" + p[0]).val(decodeURIComponent(p[1]));
             }
+            $("form#contact-form").submit(function (event){
+                $('form#contact-form').children("input, select").each(function(i, el){
+                    if(!el.value){
+                        $("#error-message").show()
+                        event.preventDefault();
+                        return false;
+                    }
+                    return true;
+                });
+            });
         })
         </script>
     </section>


### PR DESCRIPTION
This pull request adds CSS and Javascript logic to ensure the following:

1. When a user clicks on the Inquire Now button to get to the Contact page, and then attempts to submit the contact form without filling out all fields, an error message is shown:
    <img width="757" alt="screen shot 2017-09-01 at 3 11 33 pm" src="https://user-images.githubusercontent.com/7773758/29984366-1c7eb03c-8f28-11e7-9284-f011be4c5985.png">
2. The Country of Residence and Country Code fields default to the text "--Select--".
3. When submitting the form after filling out all fields, the user is redirected to the relevant course information page.
4. After being redirected to the course information page, a banner is shown indicating that the form was submitted successfully:
    <img width="1234" alt="screen shot 2017-09-01 at 3 10 00 pm" src="https://user-images.githubusercontent.com/7773758/29984454-9308f56e-8f28-11e7-87fb-03387d004990.png">

**Testing:**

1. Browse to http://pearsonx-theme.opencraft.hosting/, click on Programs, and click on the one course that appears in the list.
2. Observe that there is no banner shown.
3. Click on the Inquire Now button.
4. On the form that appears, do not fill out any fields, and click Submit
    - Observe that an error message is shown
5. Fill out the form entirely, using obviously-fake user information, and click Submit
    - Observe that you are returned to the original Course Details page
    - Observe the banner showing the inquiry success message is shown

**Notes:**

1. These changes cannot be entirely tested on a devstack, as Salesforce appears to blacklist local URLs for the URL to return to.