### PR TITLE
Email field validation; update options for "Type" field; confirmation checkbox

### DIFF
--- a/lms/static/sass/_pearsonx.scss
+++ b/lms/static/sass/_pearsonx.scss
@@ -210,6 +210,14 @@ h2 {
       .hidden-form-fields {
         display: none;
       }
+      .affirm-submission-wrapper{
+        margin-bottom: 0.5 * $baseline;
+        #affirm-submission {
+          height: auto;
+          width: auto;
+          display: inline-block;
+        }
+      }
       .contact-submit-button {
         display: block;
         flex-basis: 45%;
@@ -231,7 +239,7 @@ h2 {
           background: #1790c7;
         }
       }
-      #error-message{
+      div.error-message {
         display: none;
         background-color: $error-color;
         color: $white;

--- a/lms/templates/static_templates/contact.html
+++ b/lms/templates/static_templates/contact.html
@@ -507,9 +507,7 @@
             </select><br>
             <div class="hidden-form-fields">
                 Type (Hidden):<select  id="00N58000005kuvF" name="00N58000005kuvF" title="Type (Hidden)">
-                  <option value="">--None--</option>
-                  <option value="OPM">OPM</option>
-                  <option value="TNE">TNE</option>
+                  <option value="TNE" selected="selected">TNE</option>
                 </select><br>
 
                 Institution (Hidden):<select  id="00N58000005kuvE" name="00N58000005kuvE" title="Institution (Hidden)">
@@ -543,11 +541,21 @@
                   <option value="Blank">Blank</option>
                 </select><br>
             </div>
-            <div id="error-message">
+            <div id="required-fields-error-message" class="error-message">
                 All fields are required in order to submit this form.
             </div>
-            <button class="contact-submit-button" type="submit" name="submit">Request information</button>
-
+            <div id="invalid-email-error-message" class="error-message">
+                Please enter a valid email address.
+            </div>
+            <div class="affirm-submission-wrapper">
+                <label>
+                    <input type="checkbox" id="affirm-submission"/>
+                    I agree to be contacted via phone, text or email.
+                </label>
+            </div>
+            <button id="contact-submit-button" class="contact-submit-button" type="submit" name="submit" disabled>
+                Request information
+            </button>
             </form>
         </div>
         <script type="text/javascript">
@@ -557,15 +565,26 @@
                 var p = hashParams[i].split('=');
                 $("#" + p[0]).val(decodeURIComponent(p[1]));
             }
+            $("#affirm-submission").change(function (e) {
+                el = $("#contact-submit-button");
+                el.prop("disabled", !el.prop("disabled"));
+            });
             $("form#contact-form").submit(function (event){
                 $('form#contact-form').children("input, select").each(function(i, el){
                     if(!el.value){
-                        $("#error-message").show()
+                        $("#required-fields-error-message").show();
                         event.preventDefault();
-                        return false;
+                    }else{
+                        $("#required-fields-error-message").hide();
                     }
-                    return true;
                 });
+                emailVal = $("#email").val();
+                if(!(emailVal.split("@").length == 2)){
+                    $("#invalid-email-error-message").show();
+                    event.preventDefault();
+                }else{
+                    $("#invalid-email-error-message").hide();
+                }
             });
         })
         </script>


### PR DESCRIPTION
This change does three things:
1. Prevents SalesForce form submission if an invalid email address (matched by `name@host`) is used.
2. Blocks submission until the user checks a box affirming willingness to be contacted
3. Fixes a form field that needs to have a particular value

Test instructions:

Pull these changes and do the following:
1. While logged out, navigate to a course information page.
2. Click on the Inquire Now button
3. In the form, toggle the "I agree to be contacted..." checkbox field a couple times; note that when it's checked, the submit button for the form is enabled; when it's unchecked, the submit button is disabled.
4. In the form, leave all the fields blank and click Submit; note that in addition to the existing error about entering a value for all fields, an error requesting a valid email address is shown.
5. Fill in all fields; for the field, use a value that does not resemble an email address, and again, click Submit; verify that the other error message is gone, but that the email error remains.
6. Fill in a real-looking email address for that field, but remove a value from a different field; click Submit; verify that the email error is gone, but the error about filling out all fields is back.
7. Fill in the last field and click Submit; verify that no error occurs.