### PR TITLE
Add tracking scripts and add LinkedIn link to course about page

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -18,6 +18,25 @@ from six.moves.urllib.parse import quote
   ## (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#tags)
   <meta property="og:title" content="${course.display_name_with_default_escaped}" />
   <meta property="og:description" content="${get_course_about_section(request, course, 'short_description')}" />
+
+  <!-- Google Code for Lead Conversion Page -->
+  <script type="text/javascript">
+  /* <![CDATA[ */
+  var google_conversion_id = 838419445;
+  var google_conversion_language = "en";
+  var google_conversion_format = "3";
+  var google_conversion_color = "ffffff";
+  var google_conversion_label = "0WzCCOuDrnUQ9YfljwM";
+  var google_remarketing_only = false;
+  /* ]]> */
+  </script>
+  <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
+  </script>
+  <noscript>
+  <div style="display:inline;">
+  <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/838419445/?label=0WzCCOuDrnUQ9YfljwM&amp;guid=ON&amp;script=0"/>
+  </div>
+  </noscript>
 </%block>
 
 <%block name="js_extra">

--- a/lms/templates/courseware/course_about_sidebar_header.html
+++ b/lms/templates/courseware/course_about_sidebar_header.html
@@ -42,12 +42,17 @@ from django.conf import settings
                 )
             )
         ).replace(u" ", u"%20")
+
+        linkedin_url = "https://www.linkedin.com/company/18238258/"
       %>
       <a href="${tweet_action}" class="share">
         <span class="icon fa fa-twitter" aria-hidden="true"></span><span class="sr">${_("Tweet that you've enrolled in this course")}</span>
       </a>
       <a href="${facebook_link}" class="share">
         <span class="icon fa fa-thumbs-up" aria-hidden="true"></span><span class="sr">${_("Post a Facebook message to say you've enrolled in this course")}</span>
+      </a>
+      <a href="${linkedin_url}" class="share">
+        <span class="icon fa fa-linkedin-square" aria-hidden="true"></span><span class="sr">${_("Connect with PearsonX on LinkedIn")}</span>
       </a>
       <a href="${email_subject}" class="share">
         <span class="icon fa fa-envelope" aria-hidden="true"></span><span class="sr">${_("Email someone to say you've enrolled in this course")}</span>

--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -1,0 +1,48 @@
+<!-- Google Code for Remarketing Tag -->
+<!--
+Remarketing tags may not be associated with personally identifiable information or placed on pages related to sensitive categories. See more information and instructions on how to setup the tag on: http://google.com/ads/remarketingsetup
+-->
+<script type="text/javascript">
+/* <![CDATA[ */
+var google_conversion_id = 838419445;
+var google_custom_params = window.google_tag_params;
+var google_remarketing_only = true;
+/* ]]> */
+</script>
+<script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
+</script>
+<noscript>
+<div style="display:inline;">
+<img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/838419445/?guid=ON&amp;script=0"/>
+</div>
+</noscript>
+
+
+<!-- Global Site Tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-106763363-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments)};
+  gtag('js', new Date());
+
+  gtag('config', 'UA-106763363-1');
+</script>
+
+
+<!-- Facebook Pixel Code -->
+<script>
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '127650767882610');
+  fbq('track', 'PageView');
+</script>
+<noscript><img height="1" width="1" style="display:none"
+  src="https://www.facebook.com/tr?id=127650767882610&ev=PageView&noscript=1"
+/></noscript>
+<!-- End Facebook Pixel Code -->

--- a/lms/templates/static_templates/contact.html
+++ b/lms/templates/static_templates/contact.html
@@ -2,6 +2,29 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%inherit file="../main.html" />
 
+<%block name="headextra">
+
+<!-- Google Code for Lead Conversion Page -->
+<script type="text/javascript">
+/* <![CDATA[ */
+var google_conversion_id = 838419445;
+var google_conversion_language = "en";
+var google_conversion_format = "3";
+var google_conversion_color = "ffffff";
+var google_conversion_label = "0WzCCOuDrnUQ9YfljwM";
+var google_remarketing_only = false;
+/* ]]> */
+</script>
+<script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
+</script>
+<noscript>
+<div style="display:inline;">
+<img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/838419445/?label=0WzCCOuDrnUQ9YfljwM&amp;guid=ON&amp;script=0"/>
+</div>
+</noscript>
+
+</%block>
+
 <%block name="pagetitle">${_("Contact")}</%block>
 
 <main id="main" aria-label="Content" tabindex="-1">


### PR DESCRIPTION
This pull request adds two features - on the Course About page, there's now an additional sharing widget that links to the PearsonX LinkedIn page. Secondarily, this pull request adds analytics embeds requested by LeadMantra on behalf of PearsonX. Items appearing in `head-extra.html` should embed into all pages, as requested, and items in `course_about.html` and `contact.html` will appear only in those pages ("conversion-related" pages).