### PR TITLE
Add intake of intent field; GA tag to header

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -18,25 +18,6 @@ from six.moves.urllib.parse import quote
   ## (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#tags)
   <meta property="og:title" content="${course.display_name_with_default_escaped}" />
   <meta property="og:description" content="${get_course_about_section(request, course, 'short_description')}" />
-
-  <!-- Google Code for Lead Conversion Page -->
-  <script type="text/javascript">
-  /* <![CDATA[ */
-  var google_conversion_id = 838419445;
-  var google_conversion_language = "en";
-  var google_conversion_format = "3";
-  var google_conversion_color = "ffffff";
-  var google_conversion_label = "0WzCCOuDrnUQ9YfljwM";
-  var google_remarketing_only = false;
-  /* ]]> */
-  </script>
-  <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
-  </script>
-  <noscript>
-  <div style="display:inline;">
-  <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/838419445/?label=0WzCCOuDrnUQ9YfljwM&amp;guid=ON&amp;script=0"/>
-  </div>
-  </noscript>
 </%block>
 
 <%block name="js_extra">
@@ -241,7 +222,14 @@ from six.moves.urllib.parse import quote
               ${_("Enroll Now")}
             </a>
             % endif
-            <a href="/contact#00N61000002EYUJ=${course.display_name_with_default_escaped}&retURL=${quote(request.build_absolute_uri(request.path) + '#contacted')}" class="inquire">
+            <%
+              inquire_url = '/contact'
+              inquire_url += '#00N61000002EYUJ={}'.format(quote(course.display_name_with_default_escaped))
+              inquire_url += '&retURL={}'.format(quote(request.build_absolute_uri(request.path) + '#contacted'))
+              if not course.start_date_is_still_default:
+                inquire_url += '&00N61000002L8on={}'.format(quote(course.start.strftime('%B %Y')))
+            %>
+            <a href="${inquire_url}" class="inquire">
               ${_("Inquire Now")}
             </a>
           </div>

--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -1,48 +1,7 @@
-<!-- Google Code for Remarketing Tag -->
-<!--
-Remarketing tags may not be associated with personally identifiable information or placed on pages related to sensitive categories. See more information and instructions on how to setup the tag on: http://google.com/ads/remarketingsetup
--->
-<script type="text/javascript">
-/* <![CDATA[ */
-var google_conversion_id = 838419445;
-var google_custom_params = window.google_tag_params;
-var google_remarketing_only = true;
-/* ]]> */
-</script>
-<script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
-</script>
-<noscript>
-<div style="display:inline;">
-<img height="1" width="1" style="border-style:none;" alt="" src="//googleads.g.doubleclick.net/pagead/viewthroughconversion/838419445/?guid=ON&amp;script=0"/>
-</div>
-</noscript>
-
-
-<!-- Global Site Tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-106763363-1"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments)};
-  gtag('js', new Date());
-
-  gtag('config', 'UA-106763363-1');
-</script>
-
-
-<!-- Facebook Pixel Code -->
-<script>
-  !function(f,b,e,v,n,t,s)
-  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-  n.queue=[];t=b.createElement(e);t.async=!0;
-  t.src=v;s=b.getElementsByTagName(e)[0];
-  s.parentNode.insertBefore(t,s)}(window, document,'script',
-  'https://connect.facebook.net/en_US/fbevents.js');
-  fbq('init', '127650767882610');
-  fbq('track', 'PageView');
-</script>
-<noscript><img height="1" width="1" style="display:none"
-  src="https://www.facebook.com/tr?id=127650767882610&ev=PageView&noscript=1"
-/></noscript>
-<!-- End Facebook Pixel Code -->
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-PXNWVTR');</script>
+<!-- End Google Tag Manager -->

--- a/lms/templates/static_templates/contact.html
+++ b/lms/templates/static_templates/contact.html
@@ -2,29 +2,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%inherit file="../main.html" />
 
-<%block name="headextra">
-
-<!-- Google Code for Lead Conversion Page -->
-<script type="text/javascript">
-/* <![CDATA[ */
-var google_conversion_id = 838419445;
-var google_conversion_language = "en";
-var google_conversion_format = "3";
-var google_conversion_color = "ffffff";
-var google_conversion_label = "0WzCCOuDrnUQ9YfljwM";
-var google_remarketing_only = false;
-/* ]]> */
-</script>
-<script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
-</script>
-<noscript>
-<div style="display:inline;">
-<img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/838419445/?label=0WzCCOuDrnUQ9YfljwM&amp;guid=ON&amp;script=0"/>
-</div>
-</noscript>
-
-</%block>
-
 <%block name="pagetitle">${_("Contact")}</%block>
 
 <main id="main" aria-label="Content" tabindex="-1">
@@ -549,6 +526,9 @@ var google_remarketing_only = false;
                 </input><br>
 
                 Tertiary Source:<input  id="Tertiary_Source_c" name="00N5800000CM12L" title="Tertiary Source">
+                </input><br>
+
+                Intake of Intent:<input id="00N61000002L8on" name="00N61000002L8on" title="Intake of Intent">
                 </input><br>
             </div>
             <div id="required-fields-error-message" class="error-message">


### PR DESCRIPTION
### Changes:

This pull request adds two features.

1. Add an "Intake of Intent" field to the Inquiry form that includes the month when the course being inquired about will start. We already have a facility to fill in fields via Javascript, so this change simply adds that information to the URL that the Javascript parses and adds the field to the inquiry form.
2. Add "Google Tag Manager" to the header of all pages.

### Testing:

1. From a course that has a non-default start date set, click "Inquire Now".
2. On the Contact page, run this command:
    ```javascript
    $(".hidden-form-fields").show()
    ```
3. Verify that the "Intake of Intent" field is filled in with the UTC month and year of the course start date.

### Notes:

1. If you choose to submit the form, ensure that you use fake information including the word "Test" in as many fields as are possible. Additionally, note that if you submit from a local devstack, you will not be redirected back, as the endpoint the form hits does not redirect to localhost.