### PR TITLE
Reorganize Sass imports to fix issue with theme

### DIFF
--- a/lms/static/sass/_overrides.scss
+++ b/lms/static/sass/_overrides.scss
@@ -1,5 +1,4 @@
 @import url('https://fonts.googleapis.com/css?family=Roboto');
-@import 'base/variables';
 
 html {
   color: $base-font-color;

--- a/lms/static/sass/base/_variables.scss
+++ b/lms/static/sass/base/_variables.scss
@@ -1,3 +1,4 @@
+@import 'bourbon/bourbon';
 @import 'lms/static/sass/partials/base/variables';
 
 // Fonts

--- a/lms/static/sass/lms-main-v1.scss
+++ b/lms/static/sass/lms-main-v1.scss
@@ -1,2 +1,3 @@
+@import 'base/variables';
 @import 'lms/static/sass/lms-main-v1';
 @import 'overrides';

--- a/lms/static/sass/lms-main-v2.scss
+++ b/lms/static/sass/lms-main-v2.scss
@@ -1,2 +1,3 @@
+@import 'base/variables';
 @import 'lms/static/sass/lms-main-v2';
 @import 'overrides';


### PR DESCRIPTION
In bb4a93d, we reorganized a bunch of our Sass to fit Ginkgo better. However, this actually broke some basic theming elements.

The process Sass takes is that it simultaneously updates variables in its namespace and fills those variables into the tree of CSS styles that it generates and updates. Thus, if you want to customize variables that fill in a set of styles, those variables must be processed _prior to_ the styles they need to fill in.

The problem is that in bb4a93d, we substantially simplified `_overrides.scss` such that it imports `base/_variables.scss` as a direct dependency,  and `lms-main-v1.scss` and `lms-main-v2.scss` such that they import from the platform and _then_ import from `_overrides.scss`. As a result, because the variables are being imported _after_ the platform, they _don't take effect_ for CSS styles that are owned by the platform.

This pull request re-splits the CSS overrides and the variables that are needed for them such that our variables are brought into the namespace first, the main platform styles are calculated based on those variables, and then our theme override styles are overlaid.

CC @pomegranited as an FYI.

Sandbox: https://ondemand-new-theme.opencraft.hosting/