### PR TITLE
Responsive "about course" page

### DIFF
--- a/lms/static/sass/_pearsonx.scss
+++ b/lms/static/sass/_pearsonx.scss
@@ -304,10 +304,25 @@ section.course-info {
       }
     }
   }
+
+  .details {
+    // this @media rule can be deleted after https://github.com/edx/edx-platform/pull/16640/ is merged
+    @media screen and (max-width: 760px) {
+      float: none;
+      width: auto;
+    }
+  }
+
   .course-sidebar {
 
     header {
       margin-bottom: ($baseline * 0.5);
+    }
+
+    // this @media rule can be deleted after https://github.com/edx/edx-platform/pull/16640/ is merged
+    @media screen and (max-width: 760px) {
+      float: none;
+      width: auto;
     }
 
     .course-summary {
@@ -478,6 +493,22 @@ section.course-info {
 #contacted-message {
   display: none;
 }
+
+// this @media rule can be deleted after https://github.com/edx/edx-platform/pull/16640/ is merged
+@media screen and (max-width: 760px) {
+  .course-info {
+    header.course-profile {
+      .intro-inner-wrapper {
+        min-width: auto;
+      }
+    }
+    .container {
+      min-width: auto;
+      padding: 20px;
+    }
+  }
+}
+
 
 /*
 The below section is backported from Ginkgo to apply theming to the


### PR DESCRIPTION
This implements https://tasks.opencraft.com/browse/OC-3345 and is made to be as simple as possible: CSS only, no HTML changes, no framework changes.

See screenshots there.

## Testing
Note that you need this edx-platform branch!: https://github.com/open-craft/edx-platform/tree/opencraft-release/ginkgo.1-pearson
No migrations needed when you switch branches.
In normal ginkgo.1 this theme wouldn't display correctly.

Instructions:
1. try http://localhost:8000/courses/course-v1:edX+DemoX+Demo_Course/about
2. and make your window smaller
3. no scrollbars should appear
4. design should be reasonably good, and using the available space
5. try different sizes
6. try big screen too

## Upstreaming this
The equivalent PR upstream is: https://github.com/edx/edx-platform/pull/16640