### PR TITLE
Add temporary fix to hide Sign-up button from the main page.

### DIFF
--- a/lms/static/sass/_pearsonx.scss
+++ b/lms/static/sass/_pearsonx.scss
@@ -27,12 +27,12 @@ h2 {
     margin-left: auto;
     margin-right: auto;
     background: $white;
-  
+
     .hero-container {
       display: flex;
       flex-wrap: wrap;
     }
-    
+
     .hero-image {
       background-image: $homepage-bg-image;
       background-position: left 50% bottom 33%;
@@ -672,3 +672,12 @@ sure that the inquiry success banner still appears correctly.
   }
 }
 
+/*
+Below is a quick fix of Sign-up button
+which appeared on the main page
+likely due to some Facebook Pixel/Google Tag manager
+issue.
+*/
+body > #contact-submit-button {
+ display: none;
+}


### PR DESCRIPTION
This PR contains a quick CSS fix to hide a _Sign up_ button from the main page.

**JIRA ticket**: [OC-3363](https://tasks.opencraft.com/browse/OC-3363)

**Testing instructions**:
1. Run Pearson's devstack with this PR's branch of edx-theme. Rebuild the assets.
2. Check that there's no _Sing up_ button on the main page (http://localhost:18000)
3. Check that _Request information_ button on the contact form page is still present (http://localhost:18000/contact) (it has the same _contact-submit-button_ id as the hidden _Sign up_ button).

**Author notes and concerns**:
1. The issue of _Sing up_ button on the main page is most likely due to misconfiguration in Google Tag manager/FB Pixel as explained in [@mtyaka comment](https://tasks.opencraft.com/browse/OC-3363?focusedCommentId=53212&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-53212).

**Reviewers**:
- [ ] @pomegranited 

Signed-off-by: Tomasz Gargas <tomasz@opencraft.com>