### PR TITLE
Update activation e-mail to be easier to understand

### DIFF
--- a/lms/templates/emails/activation_email.txt
+++ b/lms/templates/emails/activation_email.txt
@@ -1,7 +1,7 @@
 <%! from django.utils.translation import ugettext as _ %>
-${_("You're almost there! Use the link to activate your account to access engaging, high-quality "
-"{platform_name} courses. Note that you will not be able to log back into your account until "
-"you have activated it.").format(platform_name=platform_name)}
+${_("You've recently registered a {platform_name} account. Please use the link below to "
+"verify your email address. You must verify your email address before you can access any "
+"programs that you purchase.").format(platform_name=platform_name)}
 
 % if is_secure:
 https://${ site }/activate/${ key }

--- a/lms/templates/emails/activation_email_subject.txt
+++ b/lms/templates/emails/activation_email_subject.txt
@@ -1,2 +1,2 @@
 <%! from django.utils.translation import ugettext as _ %>
-${_("Action Required: Activate your {platform_name} account").format(platform_name=platform_name)}
+${_("Confirm your email address")}


### PR DESCRIPTION
This changes the registration e-mail to have a simpler subject („Confirm your email address“) and body (You've recently registered a PearsonX account […]“). 
It addresses PEAR-44.
The original templates were kept at https://github.com/open-craft/edx-theme/tree/pearsonx-upstream-templates

**JIRA tickets**: None
**Discussions**: None
**Dependencies**: None
**Screenshots**: None
**Sandbox URL**: None
**Merge deadline**: None

**Testing instructions**:
1. Install PearsonX's edx-platform branch
2. register a new user
3. and check e-mail subject and body.

**Reviewers**
- [ ] @pomegranited 

**Author concerns**: None
**Settings**: None
