### PR TITLE
Rewrite course_about.html to use new blocks

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -114,10 +114,89 @@ from six.moves.urllib.parse import quote
         </div>
       </section>
     </div>
+
+    ## Note: div.main_cta was removed from here and moved into div.course-summary
+
   </header>
   </%block>
 
 <%block name="course_about_important_dates">
+## In this block we include not only ol.important-dates, but also the main-cta block which was moved from   .course-profile > .intro-inner-wrapper > .intro > .main-cta   to here   (.course-info > .course-sidebar > .course-summary > .main-cta)
+
+        <div class="main-cta">
+        %if user.is_authenticated() and registered:
+          %if show_courseware_link:
+            <a href="${course_target}">
+            <strong>${_("View Course")}</strong>
+            </a>
+          %endif
+
+        %elif in_cart:
+          <span class="add-to-cart">
+            ${_('This course is in your <a href="{cart_link}">cart</a>.').format(cart_link=cart_link)}
+          </span>
+        % elif is_course_full:
+          <span class="register disabled">
+            ${_("Course is full")}
+          </span>
+        % elif invitation_only and not can_enroll:
+          <span class="register disabled">${_("Enrollment in this course is by invitation only")}</span>
+        ## Shib courses need the enrollment button to be displayed even when can_enroll is False,
+        ## because AnonymousUsers cause can_enroll for shib courses to be False, but we need them to be able to click
+        ## so that they can register and become a real user that can enroll.
+        % elif not is_shib_course and not can_enroll:
+          <span class="register disabled">${_("Enrollment is Closed")}</span>
+        %elif can_add_course_to_cart:
+          <%
+          if user.is_authenticated():
+            reg_href = "#"
+            reg_element_id = "add_to_cart_post"
+          else:
+            reg_href = reg_then_add_to_cart_link
+            reg_element_id = "reg_then_add_to_cart"
+          %>
+          <% if ecommerce_checkout:
+              reg_href = ecommerce_checkout_link
+              reg_element_id = ""
+          %>
+          <a href="${reg_href}" class="add-to-cart" id="${reg_element_id}">
+            ${_("Add {course_name} to Cart <span>({price} USD)</span>")\
+              .format(course_name=course.display_number_with_default, price=course_price)}
+          </a>
+          <div id="register_error"></div>
+        %else:
+          <%
+            if ecommerce_checkout:
+              reg_href = ecommerce_checkout_link
+            else:
+              reg_href="#"
+            if professional_mode:
+              href_class = "add-to-cart"
+            else:
+              href_class = "register"
+          %>
+          <div class="inquire-wrapper">
+            % if not course.advertised_start:
+            <a href="${reg_href}" class="${href_class}">
+              ${_("Enroll Now")}
+            </a>
+            % endif
+            <%
+              inquire_url = '/contact'
+              inquire_url += '#00N61000002EYUJ={}'.format(quote(course.display_name_with_default_escaped))
+              inquire_url += '&retURL={}'.format(quote(request.build_absolute_uri(request.path) + '#contacted'))
+              if not course.start_date_is_still_default:
+                inquire_url += '&00N61000002L8on={}'.format(quote(course.start.strftime('%B %Y')))
+            %>
+            <a href="${inquire_url}" class="inquire">
+              ${_("Inquire Now")}
+            </a>
+          </div>
+          <div id="register_error"></div>
+        %endif
+        </div>
+
+
           <ol class="important-dates">
             <li class="important-dates-item"><span class="icon fa fa-info-circle" aria-hidden="true"></span><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default | h}</span></li>
             % if not course.start_date_is_still_default:
@@ -235,83 +314,6 @@ from six.moves.urllib.parse import quote
               </li>
             % endif
           </ol>
-</%block>
-
-
-<%block name="course_about_main_cta">
-        <div class="main-cta">
-        %if user.is_authenticated() and registered:
-          %if show_courseware_link:
-            <a href="${course_target}">
-            <strong>${_("View Course")}</strong>
-            </a>
-          %endif
-
-        %elif in_cart:
-          <span class="add-to-cart">
-            ${_('This course is in your <a href="{cart_link}">cart</a>.').format(cart_link=cart_link)}
-          </span>
-        % elif is_course_full:
-          <span class="register disabled">
-            ${_("Course is full")}
-          </span>
-        % elif invitation_only and not can_enroll:
-          <span class="register disabled">${_("Enrollment in this course is by invitation only")}</span>
-        ## Shib courses need the enrollment button to be displayed even when can_enroll is False,
-        ## because AnonymousUsers cause can_enroll for shib courses to be False, but we need them to be able to click
-        ## so that they can register and become a real user that can enroll.
-        % elif not is_shib_course and not can_enroll:
-          <span class="register disabled">${_("Enrollment is Closed")}</span>
-        %elif can_add_course_to_cart:
-          <%
-          if user.is_authenticated():
-            reg_href = "#"
-            reg_element_id = "add_to_cart_post"
-          else:
-            reg_href = reg_then_add_to_cart_link
-            reg_element_id = "reg_then_add_to_cart"
-          %>
-          <% if ecommerce_checkout:
-              reg_href = ecommerce_checkout_link
-              reg_element_id = ""
-          %>
-          <a href="${reg_href}" class="add-to-cart" id="${reg_element_id}">
-            ${_("Add {course_name} to Cart <span>({price} USD)</span>")\
-              .format(course_name=course.display_number_with_default, price=course_price)}
-          </a>
-          <div id="register_error"></div>
-        %else:
-          <%
-            if ecommerce_checkout:
-              reg_href = ecommerce_checkout_link
-            else:
-              reg_href="#"
-            if professional_mode:
-              href_class = "add-to-cart"
-            else:
-              href_class = "register"
-          %>
-          <div class="inquire-wrapper">
-            % if not course.advertised_start:
-            <a href="${reg_href}" class="${href_class}">
-              ${_("Enroll Now")}
-            </a>
-            % endif
-            <%
-              inquire_url = '/contact'
-              inquire_url += '#00N61000002EYUJ={}'.format(quote(course.display_name_with_default_escaped))
-              inquire_url += '&retURL={}'.format(quote(request.build_absolute_uri(request.path) + '#contacted'))
-              if not course.start_date_is_still_default:
-                inquire_url += '&00N61000002L8on={}'.format(quote(course.start.strftime('%B %Y')))
-            %>
-            <a href="${inquire_url}" class="inquire">
-              ${_("Inquire Now")}
-            </a>
-          </div>
-          <div id="register_error"></div>
-        %endif
-        </div>
-
 </%block>
 
 

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -72,7 +72,7 @@ from six.moves.urllib.parse import quote
 
 
 
-<%block name="course_reviews_tool">
+<%block name="course_about_reviews_tool">
 
       ## CourseTalk widget
       % if show_coursetalk_widget:
@@ -83,7 +83,23 @@ from six.moves.urllib.parse import quote
 
 </%block>
 
-  <%block name="header">
+  <%block name="course_about_header">
+  <div class="wrapper-msg urgency-info" id="contacted-message">
+    <div class="msg">
+      <span class="msg-icon fa fa-info-circle" aria-hidden="true"></span>
+      <div class="msg-content">
+        <h2 class="title">
+          Thank you for your inquiry into PearsonX and our program offerings. One of our Program Advisors will be contacting you shortly.
+        </h2>
+        <div class="copy">
+          <p>
+            We are committed to helping individuals advance in their careers and take the next step in their education goals. PearsonX provides you with globally recognized, relevant programs of study, as well as the opportunity to network with peers and progress your career.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <header class="course-profile" style="background-image: url('${course_image_url(course, 'banner_image')}')">
     <div class="intro-inner-wrapper">
       <section class="intro">
@@ -101,7 +117,7 @@ from six.moves.urllib.parse import quote
   </header>
   </%block>
 
-<%block name="important_dates">
+<%block name="course_about_important_dates">
           <ol class="important-dates">
             <li class="important-dates-item"><span class="icon fa fa-info-circle" aria-hidden="true"></span><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default | h}</span></li>
             % if not course.start_date_is_still_default:
@@ -222,25 +238,7 @@ from six.moves.urllib.parse import quote
 </%block>
 
 
-  <%block name="course_info_before_header">
-  <div class="wrapper-msg urgency-info" id="contacted-message">
-    <div class="msg">
-      <span class="msg-icon fa fa-info-circle" aria-hidden="true"></span>
-      <div class="msg-content">
-        <h2 class="title">
-          Thank you for your inquiry into PearsonX and our program offerings. One of our Program Advisors will be contacting you shortly.
-        </h2>
-        <div class="copy">
-          <p>
-            We are committed to helping individuals advance in their careers and take the next step in their education goals. PearsonX provides you with globally recognized, relevant programs of study, as well as the opportunity to network with peers and progress your career.
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-  </%block>
-
-<%block name="main_cta">
+<%block name="course_about_main_cta">
         <div class="main-cta">
         %if user.is_authenticated() and registered:
           %if show_courseware_link:

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -12,6 +12,42 @@ from xmodule.contentstore.content import StaticContent
 from six import string_types
 from six.moves.urllib.parse import quote
 %>
+##
+## What changed in relation to the upstream template
+## -------------------------------------------------      As of December 2017
+##
+## - Added Coursetalk widget JS
+## - Removed div.table (only tag, not content) in div.intro-inner-wrapper
+## - Added JS to show #contacted-message
+## - Text "edX in collaboration with" changed from <button> to <h2>
+## - Add "Thank you for your inquiry" before header.course-profile
+## - Add style="..." to header.course-profile
+## - "Enroll" button can be "Enroll" or "Inquire"
+## - Course video moved downwards in the file. From: after the Enroll button. To: after "Requirements"
+## - New date format for course_start_date
+## - Indented code for blocks about course effort and others
+## - Removed "course reviews tool"
+## - Added Coursetalk widget
+##
+## ##### ol.important-dates: #####
+## - In upstream, the shown blocks were: course number, classes start, classes end, estimated effort, course length, course price, prerequisites, requirements
+## - In ours, the shown blocks are: course number, classes start, classes end, estimated effort, institution, language, duration, course price, prerequisites, requirements
+##
+## ##### div.course-summary: #####
+## - Our div.course-summary contains: course_about_sidebar_header.html, div.main-cta, div>ol.important-dates, a>div.hero
+## - Upstream div.course-summary contains: course_about_sidebar_header.html, ol.important-dates
+##
+## ##### div.main-cta: #####
+## - Our div.main-cta contains: View course / Course is in your cart / Course is full / By invitation only / Closed / Add to cart / Enroll now / Inquire now
+## - Upstream div.main-cta contains: You are enrolled in this course / View course / Course is in your cart / Course is full / By invitation only / Closed / Add to cart / Enroll in course
+##
+## ##### section.course-info: #####
+## - Upstream's contains:  header, div.container>div.details, div.course-sidebar>div.course-summary
+## - Ours contains: div#contacted-message, header, div.container>div.details, div.course-sidebar>div.course-summary
+
+## ##### Some things that didn't change despite appearing in different positions #####
+## - "View about page in studio" is, in both templates, after closing <header>, and it's inside div.container>div.details
+
 
 <%inherit file="course_about.html" />
 

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -1,6 +1,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import get_language_info, ugettext as _
+from openedx.core.djangolib.markup import HTML
 from django.core.urlresolvers import reverse
 from courseware.courses import get_course_about_section
 from django.conf import settings
@@ -12,126 +13,41 @@ from six import string_types
 from six.moves.urllib.parse import quote
 %>
 
-<%inherit file="../main.html" />
-<%block name="headextra">
-  ## OG (Open Graph) title and description added below to give social media info to display
-  ## (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#tags)
-  <meta property="og:title" content="${course.display_name_with_default_escaped}" />
-  <meta property="og:description" content="${get_course_about_section(request, course, 'short_description')}" />
-</%block>
+<%inherit file="course_about.html" />
 
 <%block name="js_extra">
   ## CourseTalk widget js script
   % if show_coursetalk_widget:
       <script src="//d3q6qq2zt8nhwv.cloudfront.net/s/js/widgets/coursetalk-read-reviews.js"></script>
   % endif
+
+    ${HTML(parent.js_extra())}
+
   <script type="text/javascript">
   (function() {
-    $(".register").click(function(event) {
-      $("#class_enroll_form").submit();
-      event.preventDefault();
-    });
-
-    % if can_add_course_to_cart:
-      add_course_complete_handler = function(jqXHR, textStatus) {
-        if (jqXHR.status == 200) {
-          location.href = "${cart_link}";
-        }
-        if (jqXHR.status == 400) {
-          $("#register_error")
-            .html(jqXHR.responseText ? jqXHR.responseText : "${_("An error occurred. Please try again later.")}")
-            .css("display", "block");
-        }
-        else if (jqXHR.status == 403) {
-            location.href = "${reg_then_add_to_cart_link}";
-        }
-      };
-
-      $("#add_to_cart_post").click(function(event){
-        $.ajax({
-          url: "${reverse('add_course_to_cart', args=[course.id.to_deprecated_string()])}",
-          type: "POST",
-          /* Rant: HAD TO USE COMPLETE B/C PROMISE.DONE FOR SOME REASON DOES NOT WORK ON THIS PAGE. */
-          complete: add_course_complete_handler
-        })
-        event.preventDefault();
-      });
-    % endif
-
-    ## making the conditional around this entire JS block for sanity
-    %if settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
-      <%
-        perms_error = _('The currently logged-in user account does not have permission to enroll in this course. '
-                        'You may need to {start_logout_tag}log out{end_tag} then try the enroll button again. '
-                        'Please visit the {start_help_tag}help page{end_tag} for a possible solution.').format(
-                          start_help_tag="<a href='{url}'>".format(url=marketing_link('FAQ')), end_tag='</a>',
-                          start_logout_tag="<a href='{url}'>".format(url=reverse('logout'))
-                          )
-      %>
-    $('#class_enroll_form').on('ajax:complete', function(event, xhr) {
-      if(xhr.status == 200) {
-        location.href = "${reverse('dashboard')}";
-      } else if (xhr.status == 403) {
-        location.href = "${reverse('course-specific-register', args=[course.id.to_deprecated_string()])}?course_id=${course.id | u}&enrollment_action=enroll";
-      } else if (xhr.status == 400) { //This means the user did not have permission
-        $('#register_error').html("${perms_error}").css("display", "block");
-      } else {
-        $('#register_error').html(
-            (xhr.responseText ? xhr.responseText : "${_("An error occurred. Please try again later.")}")
-        ).css("display", "block");
-      }
-    });
-
-    %else:
-
-    $('#class_enroll_form').on('ajax:complete', function(event, xhr) {
-      if(xhr.status == 200) {
-        if (xhr.responseText == "") {
-          location.href = "${reverse('dashboard')}";
-        }
-        else {
-          location.href = xhr.responseText;
-        }
-      } else if (xhr.status == 403) {
-          location.href = "${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll";
-      } else {
-        $('#register_error').html(
-            (xhr.responseText ? xhr.responseText : "${_("An error occurred. Please try again later.")}")
-        ).css("display", "block");
-      }
-    });
-
-    %endif
-
     var hashParams = window.location.hash;
     if (hashParams.includes("contacted")) {
       $("#contacted-message").show();
     }
-
-  })(this)
+  })(this);
   </script>
 
-  <script src="${static.url('js/course_info.js')}"></script>
 </%block>
 
-<%block name="pagetitle">${course.display_name_with_default_escaped}</%block>
 
-<section class="course-info">
-  <div class="wrapper-msg urgency-info" id="contacted-message">
-    <div class="msg">
-      <span class="msg-icon fa fa-info-circle" aria-hidden="true"></span>
-      <div class="msg-content">
-        <h2 class="title">
-          Thank you for your inquiry into PearsonX and our program offerings. One of our Program Advisors will be contacting you shortly.
-        </h2>
-        <div class="copy">
-          <p>
-            We are committed to helping individuals advance in their careers and take the next step in their education goals. PearsonX provides you with globally recognized, relevant programs of study, as well as the opportunity to network with peers and progress your career.
-          </p>
-        </div>
+
+<%block name="course_reviews_tool">
+
+      ## CourseTalk widget
+      % if show_coursetalk_widget:
+      <div class="coursetalk-read-reviews">
+          <div id="ct-custom-read-review-widget" data-provider="${platform_key}" data-course="${course_review_key}"></div>
       </div>
-    </div>
-  </div>
+      % endif
+
+</%block>
+
+  <%block name="header">
   <header class="course-profile" style="background-image: url('${course_image_url(course, 'banner_image')}')">
     <div class="intro-inner-wrapper">
       <section class="intro">
@@ -147,96 +63,9 @@ from six.moves.urllib.parse import quote
       </section>
     </div>
   </header>
+  </%block>
 
-  <div class="container">
-    <div class="details">
-      % if staff_access and studio_url is not None:
-        <div class="wrap-instructor-info studio-view">
-          <a class="instructor-info-action" href="${studio_url}">${_("View About Page in studio")}</a>
-        </div>
-      % endif
-
-      <div class="inner-wrapper">
-        ${get_course_about_section(request, course, "overview")}
-      </div>
-  </div>
-
-    <div class="course-sidebar">
-      <div class="course-summary">
-        <%include file="course_about_sidebar_header.html" />
-        <div class="main-cta">
-        %if user.is_authenticated() and registered:
-          %if show_courseware_link:
-            <a href="${course_target}">
-            <strong>${_("View Course")}</strong>
-            </a>
-          %endif
-
-        %elif in_cart:
-          <span class="add-to-cart">
-            ${_('This course is in your <a href="{cart_link}">cart</a>.').format(cart_link=cart_link)}
-          </span>
-        % elif is_course_full:
-          <span class="register disabled">
-            ${_("Course is full")}
-          </span>
-        % elif invitation_only and not can_enroll:
-          <span class="register disabled">${_("Enrollment in this course is by invitation only")}</span>
-        ## Shib courses need the enrollment button to be displayed even when can_enroll is False,
-        ## because AnonymousUsers cause can_enroll for shib courses to be False, but we need them to be able to click
-        ## so that they can register and become a real user that can enroll.
-        % elif not is_shib_course and not can_enroll:
-          <span class="register disabled">${_("Enrollment is Closed")}</span>
-        %elif can_add_course_to_cart:
-          <%
-          if user.is_authenticated():
-            reg_href = "#"
-            reg_element_id = "add_to_cart_post"
-          else:
-            reg_href = reg_then_add_to_cart_link
-            reg_element_id = "reg_then_add_to_cart"
-          %>
-          <% if ecommerce_checkout:
-              reg_href = ecommerce_checkout_link
-              reg_element_id = ""
-          %>
-          <a href="${reg_href}" class="add-to-cart" id="${reg_element_id}">
-            ${_("Add {course_name} to Cart <span>({price} USD)</span>")\
-              .format(course_name=course.display_number_with_default, price=course_price)}
-          </a>
-          <div id="register_error"></div>
-        %else:
-          <%
-            if ecommerce_checkout:
-              reg_href = ecommerce_checkout_link
-            else:
-              reg_href="#"
-            if professional_mode:
-              href_class = "add-to-cart"
-            else:
-              href_class = "register"
-          %>
-          <div class="inquire-wrapper">
-            % if not course.advertised_start:
-            <a href="${reg_href}" class="${href_class}">
-              ${_("Enroll Now")}
-            </a>
-            % endif
-            <%
-              inquire_url = '/contact'
-              inquire_url += '#00N61000002EYUJ={}'.format(quote(course.display_name_with_default_escaped))
-              inquire_url += '&retURL={}'.format(quote(request.build_absolute_uri(request.path) + '#contacted'))
-              if not course.start_date_is_still_default:
-                inquire_url += '&00N61000002L8on={}'.format(quote(course.start.strftime('%B %Y')))
-            %>
-            <a href="${inquire_url}" class="inquire">
-              ${_("Inquire Now")}
-            </a>
-          </div>
-          <div id="register_error"></div>
-        %endif
-        </div>
-        <div>
+<%block name="important_dates">
           <ol class="important-dates">
             <li class="important-dates-item"><span class="icon fa fa-info-circle" aria-hidden="true"></span><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default | h}</span></li>
             % if not course.start_date_is_still_default:
@@ -354,65 +183,103 @@ from six.moves.urllib.parse import quote
               </li>
             % endif
           </ol>
-        </div>
+</%block>
 
-        % if get_course_about_section(request, course, "video"):
-        <a href="#video-modal" class="media" rel="leanModal">
-          <div class="hero">
-            <img src="${course_image_urls['large']}" alt="" />
-            <div class="play-intro"></div>
+
+  <%block name="course_info_before_header">
+  <div class="wrapper-msg urgency-info" id="contacted-message">
+    <div class="msg">
+      <span class="msg-icon fa fa-info-circle" aria-hidden="true"></span>
+      <div class="msg-content">
+        <h2 class="title">
+          Thank you for your inquiry into PearsonX and our program offerings. One of our Program Advisors will be contacting you shortly.
+        </h2>
+        <div class="copy">
+          <p>
+            We are committed to helping individuals advance in their careers and take the next step in their education goals. PearsonX provides you with globally recognized, relevant programs of study, as well as the opportunity to network with peers and progress your career.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  </%block>
+
+<%block name="main_cta">
+        <div class="main-cta">
+        %if user.is_authenticated() and registered:
+          %if show_courseware_link:
+            <a href="${course_target}">
+            <strong>${_("View Course")}</strong>
+            </a>
+          %endif
+
+        %elif in_cart:
+          <span class="add-to-cart">
+            ${_('This course is in your <a href="{cart_link}">cart</a>.').format(cart_link=cart_link)}
+          </span>
+        % elif is_course_full:
+          <span class="register disabled">
+            ${_("Course is full")}
+          </span>
+        % elif invitation_only and not can_enroll:
+          <span class="register disabled">${_("Enrollment in this course is by invitation only")}</span>
+        ## Shib courses need the enrollment button to be displayed even when can_enroll is False,
+        ## because AnonymousUsers cause can_enroll for shib courses to be False, but we need them to be able to click
+        ## so that they can register and become a real user that can enroll.
+        % elif not is_shib_course and not can_enroll:
+          <span class="register disabled">${_("Enrollment is Closed")}</span>
+        %elif can_add_course_to_cart:
+          <%
+          if user.is_authenticated():
+            reg_href = "#"
+            reg_element_id = "add_to_cart_post"
+          else:
+            reg_href = reg_then_add_to_cart_link
+            reg_element_id = "reg_then_add_to_cart"
+          %>
+          <% if ecommerce_checkout:
+              reg_href = ecommerce_checkout_link
+              reg_element_id = ""
+          %>
+          <a href="${reg_href}" class="add-to-cart" id="${reg_element_id}">
+            ${_("Add {course_name} to Cart <span>({price} USD)</span>")\
+              .format(course_name=course.display_number_with_default, price=course_price)}
+          </a>
+          <div id="register_error"></div>
+        %else:
+          <%
+            if ecommerce_checkout:
+              reg_href = ecommerce_checkout_link
+            else:
+              reg_href="#"
+            if professional_mode:
+              href_class = "add-to-cart"
+            else:
+              href_class = "register"
+          %>
+          <div class="inquire-wrapper">
+            % if not course.advertised_start:
+            <a href="${reg_href}" class="${href_class}">
+              ${_("Enroll Now")}
+            </a>
+            % endif
+            <%
+              inquire_url = '/contact'
+              inquire_url += '#00N61000002EYUJ={}'.format(quote(course.display_name_with_default_escaped))
+              inquire_url += '&retURL={}'.format(quote(request.build_absolute_uri(request.path) + '#contacted'))
+              if not course.start_date_is_still_default:
+                inquire_url += '&00N61000002L8on={}'.format(quote(course.start.strftime('%B %Y')))
+            %>
+            <a href="${inquire_url}" class="inquire">
+              ${_("Inquire Now")}
+            </a>
           </div>
-        </a>
-        % endif
-    </div>
-
-      ## CourseTalk widget
-      % if show_coursetalk_widget:
-      <div class="coursetalk-read-reviews">
-          <div id="ct-custom-read-review-widget" data-provider="${platform_key}" data-course="${course_review_key}"></div>
-      </div>
-      % endif
-
-      ## For now, ocw links are the only thing that goes in additional resources
-      % if get_course_about_section(request, course, "ocw_links"):
-      <div class="additional-resources">
-        <header>
-          <h1>${_("Additional Resources")}</h1>
-      </div>
-
-        <div>
-          ## "MITOpenCourseware" should *not* be translated
-          <h2 class="opencourseware">MITOpenCourseware</h2>
-             ${get_course_about_section(request, course, "ocw_links")}
+          <div id="register_error"></div>
+        %endif
         </div>
-    </div>
-      %endif
 
-  </div>
+</%block>
 
-  </div>
-</div>
 
-## Need to put this hidden form on the page so that the registration button works.
-## Since it's no harm to display a hidden form, we display it with the most permissive conditional
-## which is when the student is not registered.
-%if active_reg_button or is_shib_course:
-  <div style="display: none;">
-    <form id="class_enroll_form" method="post" data-remote="true" action="${reverse('change_enrollment')}">
-      <fieldset class="enroll_fieldset">
-        <legend class="sr">${_("Enroll")}</legend>
-        <input name="course_id" type="hidden" value="${course.id | h}">
-        <input name="enrollment_action" type="hidden" value="enroll">
-      </fieldset>
-      <div class="submit">
-        <input name="submit" type="submit" value="${_('enroll')}">
-      </div>
-    </form>
-  </div>
-%endif
+${HTML(parent.body())}
 
-<%include file="../video_modal.html" />
-
-<%static:require_module_async module_name="js/dateutil_factory" class_name="DateUtilFactory">
-    DateUtilFactory.transform(iterationKey=".localized_datetime");
-</%static:require_module_async>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -54,10 +54,10 @@ from six.moves.urllib.parse import quote
 <%block name="js_extra">
   ## CourseTalk widget js script
   % if show_coursetalk_widget:
-      <script src="//d3q6qq2zt8nhwv.cloudfront.net/s/js/widgets/coursetalk-read-reviews.js"></script>
+  <script src="//d3q6qq2zt8nhwv.cloudfront.net/s/js/widgets/coursetalk-read-reviews.js"></script>
   % endif
 
-    ${HTML(parent.js_extra())}
+  ${HTML(parent.js_extra())}
 
   <script type="text/javascript">
   (function() {
@@ -77,13 +77,13 @@ from six.moves.urllib.parse import quote
       ## CourseTalk widget
       % if show_coursetalk_widget:
       <div class="coursetalk-read-reviews">
-          <div id="ct-custom-read-review-widget" data-provider="${platform_key}" data-course="${course_review_key}"></div>
+        <div id="ct-custom-read-review-widget" data-provider="${platform_key}" data-course="${course_review_key}"></div>
       </div>
       % endif
 
 </%block>
 
-  <%block name="course_about_header">
+<%block name="course_about_header">
   <div class="wrapper-msg urgency-info" id="contacted-message">
     <div class="msg">
       <span class="msg-icon fa fa-info-circle" aria-hidden="true"></span>
@@ -118,12 +118,12 @@ from six.moves.urllib.parse import quote
     ## Note: div.main_cta was removed from here and moved into div.course-summary
 
   </header>
-  </%block>
+</%block>
 
 <%block name="course_about_important_dates">
 ## In this block we include not only ol.important-dates, but these other components:
 ## - first, the main-cta block which was moved from   .course-profile > .intro-inner-wrapper > .intro > .main-cta   to here   (.course-info > .course-sidebar > .course-summary > .main-cta)
-## - then, the ol.important-date itself
+## - then, the ol.important-dates itself
 ## - then, a#video-modal
 
         <div class="main-cta">
@@ -200,135 +200,133 @@ from six.moves.urllib.parse import quote
         </div>
 
 
-          <ol class="important-dates">
-            <li class="important-dates-item"><span class="icon fa fa-info-circle" aria-hidden="true"></span><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default | h}</span></li>
-            % if not course.start_date_is_still_default:
-                <%
-                    course_start_date = course.advertised_start or course.start
-                %>
-              <li class="important-dates-item">
-                <span class="icon fa fa-calendar" aria-hidden="true"></span>
-                <p class="important-dates-item-title">${_("Classes Start")}</p>
-                % if isinstance(course_start_date, string_types):
-                    <span class="important-dates-item-text start-date">${course_start_date}</span>
-                % else:
-                    <%
-                       course_date_string = course_start_date.strftime('%Y-%m-%dT%H:%M:%S%z')
-                    %>
-                    <span class="important-dates-item-text start-date localized_datetime" data-format="shortDate" data-datetime="${course_date_string}"></span>
-                % endif
-              </li>
-            % endif
-              ## We plan to ditch end_date (which is not stored in course metadata),
-              ## but for backwards compatibility, show about/end_date blob if it exists.
-              % if get_course_about_section(request, course, "end_date") or course.end:
+        <ol class="important-dates">
+          <li class="important-dates-item"><span class="icon fa fa-info-circle" aria-hidden="true"></span><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default | h}</span></li>
+          % if not course.start_date_is_still_default:
+              <%
+                  course_start_date = course.advertised_start or course.start
+              %>
+            <li class="important-dates-item">
+              <span class="icon fa fa-calendar" aria-hidden="true"></span>
+              <p class="important-dates-item-title">${_("Classes Start")}</p>
+              % if isinstance(course_start_date, string_types):
+                  <span class="important-dates-item-text start-date">${course_start_date}</span>
+              % else:
                   <%
-                      course_end_date = course.end
+                     course_date_string = course_start_date.strftime('%Y-%m-%dT%H:%M:%S%z')
                   %>
-
-              <li class="important-dates-item">
-                  <span class="icon fa fa-calendar" aria-hidden="true"></span>
-                  <p class="important-dates-item-title">${_("Classes End")}</p>
-                    % if isinstance(course_end_date, str):
-                        <span class="important-dates-item-text final-date">${course_end_date}</span>
-                    % else:
-                      <%
-                          course_date_string = course_end_date.strftime('%Y-%m-%dT%H:%M:%S%z')
-                      %>
-                      <span class="important-dates-item-text final-date localized_datetime" data-format="shortDate" data-datetime="${course_date_string}"></span>
-                    % endif
-              </li>
+                  <span class="important-dates-item-text start-date localized_datetime" data-format="shortDate" data-datetime="${course_date_string}"></span>
               % endif
+            </li>
+          % endif
+            ## We plan to ditch end_date (which is not stored in course metadata),
+            ## but for backwards compatibility, show about/end_date blob if it exists.
+            % if get_course_about_section(request, course, "end_date") or course.end:
+                <%
+                    course_end_date = course.end
+                %>
 
-            ## Effort
-            % if get_course_about_section(request, course, "effort"):
-              <li class="important-dates-item">
-                <span class="icon fa fa-pencil" aria-hidden="true"></span>
-                <p class="important-dates-item-title">${_("Estimated Effort")}</p>
-                <span class="important-dates-item-text effort">${get_course_about_section(request, course, "effort")}</span>
-              </li>
-            % endif
-
-            ## Organization / Institute
-            % if course.display_org_with_default:
-              <li class="important-dates-item">
-                <span class="icon fa fa-university" aria-hidden="true"></span>
-                <p class="important-dates-item-title">${_("Institution")}</p>
-                <span class="important-dates-item-text institution">${course.display_org_with_default}</span>
-              </li>
-            % endif
-
-            ## Language
-            % if course_details.language:
-              <li class="important-dates-item">
-                <span class="icon fa fa-language" aria-hidden="true"></span>
-                <p class="important-dates-item-title">${_("Language")}</p>
-                <span class="important-dates-item-text language">${get_language_info(course_details.language)['name_local']}</span>
-              </li>
-            % endif
-
-            ## Pull course run info from course discovery
-            <%
-              discovery_course_run_details = get_course_run_details(course.id.to_deprecated_string(), ['weeks_to_complete'])
-            %>
-
-            ## Duration
-            % if discovery_course_run_details.get('weeks_to_complete'):
-              <li class="important-dates-item">
-                <span class="icon fa fa-clock-o" aria-hidden="true"></span>
-                <p class="important-dates-item-title">${_("Duration")}</p>
-                <span class="important-dates-item-text duration">${_("{} Weeks").format(discovery_course_run_details['weeks_to_complete'])}</span>
-              </li>
-            % endif
-
-            ## Price
-            %if course_price and (can_add_course_to_cart or is_cosmetic_price_enabled):
-              <li class="important-dates-item">
-                <span class="icon fa fa-money" aria-hidden="true"></span>
-                <p class="important-dates-item-title">${_("Price")}</p>
-                <span class="important-dates-item-text">${course_price}</span>
-              </li>
-            %endif
-
-            ## Prerequisites
-            % if pre_requisite_courses:
-            <% prc_target = reverse('about_course', args=[unicode(pre_requisite_courses[0]['key'])]) %>
-            <li class="prerequisite-course important-dates-item">
-              <span class="icon fa fa-list-ul" aria-hidden="true"></span>
-              <p class="important-dates-item-title">${_("Prerequisites")}</p>
-              ## Multiple pre-requisite courses are not supported on frontend that's why we are pulling first element
-              <span class="important-dates-item-text pre-requisite"><a href="${prc_target}">${pre_requisite_courses[0]['display']}</a></span>
-              <p class="tip">
-              ${_("You must successfully complete {link_start}{prc_display}{link_end} before you begin this course.").format(
-                link_start='<a href="{}">'.format(prc_target),
-                link_end='</a>',
-                prc_display=pre_requisite_courses[0]['display'],
-              )}
-              </p>
+            <li class="important-dates-item">
+                <span class="icon fa fa-calendar" aria-hidden="true"></span>
+                <p class="important-dates-item-title">${_("Classes End")}</p>
+                  % if isinstance(course_end_date, str):
+                      <span class="important-dates-item-text final-date">${course_end_date}</span>
+                  % else:
+                    <%
+                        course_date_string = course_end_date.strftime('%Y-%m-%dT%H:%M:%S%z')
+                    %>
+                    <span class="important-dates-item-text final-date localized_datetime" data-format="shortDate" data-datetime="${course_date_string}"></span>
+                  % endif
             </li>
             % endif
 
-            ## Requirements
-            % if get_course_about_section(request, course, "prerequisites"):
-              <li class="important-dates-item">
-                <span class="icon fa fa-book" aria-hidden="true"></span>
-                <p class="important-dates-item-title">${_("Requirements")}</p>
-                <span class="important-dates-item-text prerequisites">${get_course_about_section(request, course, "prerequisites")}</span>
-              </li>
-            % endif
-          </ol>
-
-          % if get_course_about_section(request, course, "video"):
-          <a href="#video-modal" class="media" rel="leanModal">
-            <div class="hero">
-              <img src="${course_image_urls['large']}" alt="" />
-              <div class="play-intro"></div>
-            </div>
-          </a>
+          ## Effort
+          % if get_course_about_section(request, course, "effort"):
+            <li class="important-dates-item">
+              <span class="icon fa fa-pencil" aria-hidden="true"></span>
+              <p class="important-dates-item-title">${_("Estimated Effort")}</p>
+              <span class="important-dates-item-text effort">${get_course_about_section(request, course, "effort")}</span>
+            </li>
           % endif
+
+          ## Organization / Institute
+          % if course.display_org_with_default:
+            <li class="important-dates-item">
+              <span class="icon fa fa-university" aria-hidden="true"></span>
+              <p class="important-dates-item-title">${_("Institution")}</p>
+              <span class="important-dates-item-text institution">${course.display_org_with_default}</span>
+            </li>
+          % endif
+
+          ## Language
+          % if course_details.language:
+            <li class="important-dates-item">
+              <span class="icon fa fa-language" aria-hidden="true"></span>
+              <p class="important-dates-item-title">${_("Language")}</p>
+              <span class="important-dates-item-text language">${get_language_info(course_details.language)['name_local']}</span>
+            </li>
+          % endif
+
+          ## Pull course run info from course discovery
+          <%
+            discovery_course_run_details = get_course_run_details(course.id.to_deprecated_string(), ['weeks_to_complete'])
+          %>
+
+          ## Duration
+          % if discovery_course_run_details.get('weeks_to_complete'):
+            <li class="important-dates-item">
+              <span class="icon fa fa-clock-o" aria-hidden="true"></span>
+              <p class="important-dates-item-title">${_("Duration")}</p>
+              <span class="important-dates-item-text duration">${_("{} Weeks").format(discovery_course_run_details['weeks_to_complete'])}</span>
+            </li>
+          % endif
+
+          ## Price
+          %if course_price and (can_add_course_to_cart or is_cosmetic_price_enabled):
+            <li class="important-dates-item">
+              <span class="icon fa fa-money" aria-hidden="true"></span>
+              <p class="important-dates-item-title">${_("Price")}</p>
+              <span class="important-dates-item-text">${course_price}</span>
+            </li>
+          %endif
+
+          ## Prerequisites
+          % if pre_requisite_courses:
+          <% prc_target = reverse('about_course', args=[unicode(pre_requisite_courses[0]['key'])]) %>
+          <li class="prerequisite-course important-dates-item">
+            <span class="icon fa fa-list-ul" aria-hidden="true"></span>
+            <p class="important-dates-item-title">${_("Prerequisites")}</p>
+            ## Multiple pre-requisite courses are not supported on frontend that's why we are pulling first element
+            <span class="important-dates-item-text pre-requisite"><a href="${prc_target}">${pre_requisite_courses[0]['display']}</a></span>
+            <p class="tip">
+            ${_("You must successfully complete {link_start}{prc_display}{link_end} before you begin this course.").format(
+              link_start='<a href="{}">'.format(prc_target),
+              link_end='</a>',
+              prc_display=pre_requisite_courses[0]['display'],
+            )}
+            </p>
+          </li>
+          % endif
+
+          ## Requirements
+          % if get_course_about_section(request, course, "prerequisites"):
+            <li class="important-dates-item">
+              <span class="icon fa fa-book" aria-hidden="true"></span>
+              <p class="important-dates-item-title">${_("Requirements")}</p>
+              <span class="important-dates-item-text prerequisites">${get_course_about_section(request, course, "prerequisites")}</span>
+            </li>
+          % endif
+        </ol>
+
+        % if get_course_about_section(request, course, "video"):
+        <a href="#video-modal" class="media" rel="leanModal">
+          <div class="hero">
+            <img src="${course_image_urls['large']}" alt="" />
+            <div class="play-intro"></div>
+          </div>
+        </a>
+        % endif
 
 </%block>
 
-
 ${HTML(parent.body())}
-

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -121,7 +121,10 @@ from six.moves.urllib.parse import quote
   </%block>
 
 <%block name="course_about_important_dates">
-## In this block we include not only ol.important-dates, but also the main-cta block which was moved from   .course-profile > .intro-inner-wrapper > .intro > .main-cta   to here   (.course-info > .course-sidebar > .course-summary > .main-cta)
+## In this block we include not only ol.important-dates, but these other components:
+## - first, the main-cta block which was moved from   .course-profile > .intro-inner-wrapper > .intro > .main-cta   to here   (.course-info > .course-sidebar > .course-summary > .main-cta)
+## - then, the ol.important-date itself
+## - then, a#video-modal
 
         <div class="main-cta">
         %if user.is_authenticated() and registered:
@@ -314,6 +317,16 @@ from six.moves.urllib.parse import quote
               </li>
             % endif
           </ol>
+
+          % if get_course_about_section(request, course, "video"):
+          <a href="#video-modal" class="media" rel="leanModal">
+            <div class="hero">
+              <img src="${course_image_urls['large']}" alt="" />
+              <div class="play-intro"></div>
+            </div>
+          </a>
+          % endif
+
 </%block>
 
 


### PR DESCRIPTION
This, together with https://github.com/open-craft/edx-platform/pull/96, makes the Pearson theme continue working with no design changes, but simplifies the HTML (in about_course.html only) and makes it easier to maintain.
It uses a new way of creating themes: by inheriting from the base theme and redefining only the blocks that change. For this it requires the code in https://github.com/edx/edx-platform/pull/16856/commits and the named blocks in https://github.com/open-craft/edx-platform/pull/96
It also add explanations about what was changed in the Pearson theme, which should help when we migrate this theme to a newer Open edX release.

**JIRA tickets**: None
**Discussions**: None
**Dependencies**: None
**Screenshots**: None
**Sandbox URL**: None
**Merge deadline**: None

**Testing instructions**:

1. Either:
    - Deploy in a server which includes both https://github.com/edx/edx-platform/pull/16856 and  https://github.com/open-craft/edx-platform/pull/96 on top of the pearson branch  https://github.com/open-craft/edx-platform/tree/opencraft-release/ginkgo.1-pearson (it's based on ginkgo.1; works in vagrant and docker)
    - or log in to the one in https://console.opencraft.com/instance/2760/edx-appserver/4118/ , where I already did those changes
2. Create or change the introduction course to add  a video so that we test all components. (Or if using Ocim's appserver, locate a course with video, e.g. the one about digital marketing)
3. Visit http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/about (or https://courses.pearsonx.com/courses/course-v1:WhartonX+DM-17-18+2017-18_T1/about if you're using the Ocim appserver), you're still seeing the original page (this PR is unapplied yet). Save the HTML to a file
4. Activate the theme in this PR (not needed if using the Ocim appserver because it's already enabled) 
5. Go to the same page in the theme-enabled appserver and save the HTML to another file
6. Compare both HTMLs, they should be +the same+ equivalent. That is, the original one (no blocks) and the new one (which only defines specific blocks) should produce a complete page. Only two things changed:
    - A lone `<div>` around `<ol class="important-dates">` was removed; this doesn't modify the design (check it visually)
    - The JS order was changed. To check that it's working, try http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/about#contacted too (it shows a new blue box)
7. Compare visually with https://courses.pearsonx.com/courses/course-v1:ThunderbirdX+IBM-17-18+2018_T2/about or with the course you chose
8. Test that the page is still responsive in small screen
9. Try the video part by clicking it
10. Read the explanations about what was changed in the Pearson branch. Compare them with this diff (base ginkgo.1 templates → our Pearson templates): https://github.com/open-craft/edx-theme/compare/pearsonx-upstream-templates...open-craft:pearsonx (only for course_about.html)

**Reviewers**
- [ ] @mtyaka 

**Author concerns**: None
**Settings**: None
