### PR TITLE
Adds 2nd Google Tag Manager container

### DIFF
--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -4,4 +4,9 @@ new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-PXNWVTR');</script>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MD67JR7');</script>
 <!-- End Google Tag Manager -->


### PR DESCRIPTION
Adds a second Google Tag Manager container as per client request.

[Google says this should work fine](https://developers.google.com/tag-manager/devguide#multiple-containers), so long as they're sharing the same data layer.

**Merge deadline**: ASAP

**Testing Instructions**
1. Use this theme on a gingko devstack by:
  * Cloning this branch to `/edx/app/edxapp/themes/pearson`
  * Setting these values in the `/edx/app/edxapp/*.env.json` files:
   ```json
    "COMPREHENSIVE_THEME_DIRS": [
        "/edx/app/edxapp/themes"
    ],
    "DEFAULT_SITE_THEME": "pearson",
    "ENABLE_COMPREHENSIVE_THEMING": true,
   ```
1. Ensure that both the original `GTM-PXNWVTR` and `GTM-MD67JR7` GTM containers are loaded and present in the `<head>`.

**Author notes and concerns**:

* I haven't added the corresponding `<noscript>` block, because they weren't added for the original GTM account, and the Open edX platform doesn't function without Javascript anyway.

**Reviewer**
- [ ] @clemente