### PR TITLE
"Enquire now" form: 3 new fields, spinner after submit, inquire→enquire

### DIFF
--- a/lms/static/sass/_pearsonx.scss
+++ b/lms/static/sass/_pearsonx.scss
@@ -238,6 +238,9 @@ h2 {
         &:hover {
           background: #1790c7;
         }
+        .icon.fa.fa-spinner {
+          display: none;
+        }
       }
       div.error-message {
         display: none;

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -191,8 +191,9 @@ from six.moves.urllib.parse import quote
               if not course.start_date_is_still_default:
                 inquire_url += '&00N61000002L8on={}'.format(quote(course.start.strftime('%B %Y')))
             %>
+            ## The preferred spelling is Enquire. PEAR-48
             <a href="${inquire_url}" class="inquire">
-              ${_("Inquire Now")}
+              ${_("Enquire Now")}
             </a>
           </div>
           <div id="register_error"></div>

--- a/lms/templates/static_templates/contact.html
+++ b/lms/templates/static_templates/contact.html
@@ -530,6 +530,13 @@
 
                 Intake of Intent:<input id="00N61000002L8on" name="00N61000002L8on" title="Intake of Intent">
                 </input><br>
+
+                Content:<input  id="00N5800000DLC7v" maxlength="255" name="00N5800000DLC7v" size="20" type="text" /><br>
+ 
+                Medium:<input  id="00N5800000DLC7w" maxlength="255" name="00N5800000DLC7w" size="20" type="text" /><br>
+ 
+                Term (Keyword):<input  id="00N5800000DLC7x" maxlength="255" name="00N5800000DLC7x" size="20" type="text" /><br>
+ 
             </div>
             <div id="required-fields-error-message" class="error-message">
                 All fields are required in order to submit this form.

--- a/lms/templates/static_templates/contact.html
+++ b/lms/templates/static_templates/contact.html
@@ -551,6 +551,7 @@
                 </label>
             </div>
             <button id="contact-submit-button" class="contact-submit-button" type="submit" name="submit" disabled>
+                <span class="icon fa fa-spinner fa-spin" aria-hidden="true"></span>
                 Request information
             </button>
             </form>
@@ -573,13 +574,16 @@
                   }
             );
             $("#affirm-submission").change(function (e) {
+                var affirms = $("#affirm-submission").is(':checked');
                 el = $("#contact-submit-button");
-                el.prop("disabled", !el.prop("disabled"));
+                el.prop("disabled", !affirms);
             });
             $("form#contact-form").submit(function (event){
+                var errors = false;
                 $('form#contact-form').children("input, select").each(function(i, el){
                     if(!el.value){
                         $("#required-fields-error-message").show();
+                        errors = true;
                         event.preventDefault();
                     }else{
                         $("#required-fields-error-message").hide();
@@ -588,10 +592,28 @@
                 emailVal = $("#email").val();
                 if(!(emailVal.split("@").length == 2)){
                     $("#invalid-email-error-message").show();
+                    errors = true;
                     event.preventDefault();
                 }else{
                     $("#invalid-email-error-message").hide();
                 }
+
+                if(!errors) {
+                    // Form being submitted
+
+                    // Disable clicking the submit button again, to avoid double form submissions
+                    el = $("#contact-submit-button");
+                    el.prop("disabled", true);
+
+                    // Also disable checkbox, to avoid making the button clickable again
+                    el = $("#affirm-submission");
+                    el.prop("disabled", true);
+
+                    // Show spinner
+                    el = $("#contact-submit-button .icon.fa.fa-spinner");
+                    el.css("display", "inline-block");
+                }
+
             });
         })
         </script>


### PR DESCRIPTION
This addresses  OC-3890 [PEAR-47] [PEAR-48] [PEAR-49] .

To test this:

1. Use the sandbox, e.g. https://pearson-test.sandbox.stage.opencraft.hosting/contact#00N61000002EYUJ=Some%20other%20course&retURL=https%3A//pearson-test.sandbox.stage.opencraft.hosting/courses/course-v1%3Atesting1%2Bother2%2B2018_02/about%23contacted , where I already enabled this theme
2. Note that in the HTML, I replaced (but not commited to git) the Pearson code, it says `nononononono…` instead of their original. In this way you can submit the form to SalesForce many times without affecting their data
3. Check in the HTML that 3 new fields appear: content, medium, term
4. Check that the button says „enquire“, not „inquire“
5. The most important: the button. Half-fill the form, the button is still disabled. Click the checkbox, it should be enabled. Click the button, it should warn you of errors and still be clickable.
6. Correctly fill the form and click the button, it should be temporarily disabled while it's sending. Try clicking it faster, it won't work.
7. You should also see a circle spinning inside the button while the form is sending.
8. Try it in slow motion. To do this, go to your `/etc/resolv.conf` and change your DNS to a non-existant IP (`192.168.14.28`). Restart the browser if it uses caché. Add a fake entry for this particular domain to `/etc/hosts` so that it works, if needed. Then, submit the form. The DNS resolution of the SalesForce domain will take very long, and you will the button disabled, unclickable, and the spinner spinning


Note that I changed the way the „I agree“ checkbox works: before, it just toggled the button on→off→on→off→…. Now, because the button can be toggled due to other reasons, I made it follow the logic „if the user doesn't agree, the button is disabled“.
