### PR TITLE
OC-3930: Add Google verification meta tag to the PearsonX server

### DIFF
--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -10,3 +10,4 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-MD67JR7');</script>
 <!-- End Google Tag Manager -->
+<meta name="google-site-verification" content="YlD5RfeALAJ9dKauCEpOqKLIWHJz3U4y_GXTXEnggWw" />


### PR DESCRIPTION
Adding meta tag with the Google site verification ID.

**JIRA tickets**: OC-3930

**Dependencies**: None

**Sandbox URL**: TBD - https://pearson-test.sandbox.stage.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:

1. Check whether the meta tag is present on the instance

**Author notes and concerns**:

This will get tested directly on the appserver, as it is just a very minor change

**Reviewers**
- [Kshitij]