### PR TITLE
Add additional "Enquire now" button on small screens

### DIFF
--- a/lms/static/sass/_pearsonx.scss
+++ b/lms/static/sass/_pearsonx.scss
@@ -280,6 +280,31 @@ h2 {
   }
 }
 
+// Used for call-to-action buttons (enroll now, inquire now, add to cart, …) in course_about page
+@mixin inquire-now-blue-button {
+  @include box-sizing(border-box);
+  border-radius: 3px;
+  font: normal 1.2rem/1.6rem $sans-serif;
+  display: block;
+  flex-basis: 45%;
+  align-items: baseline;
+  box-shadow: 0 2px 1px 0 #0a4a67;
+  background: #126f9a;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  text-align: center;
+  text-shadow: none;
+  font-weight: 500;
+  letter-spacing: 0;
+  transition: color 0.25s ease-in-out, background 0.25s ease-in-out, box-shadow 0.25s ease-in-out;
+  margin: 0px ($baseline * 0.25) ($baseline * 0.5);
+  min-width: 150px;
+  &:hover {
+    background: #1790c7;
+  }
+}
+
 section.course-info {
   header.course-profile {
     padding-top: 0px;
@@ -314,6 +339,15 @@ section.course-info {
       float: none;
       width: auto;
     }
+
+    // Second inquire button, only visible in small screens
+    a.inquire {
+      @include inquire-now-blue-button;
+      @media screen and (min-width: 760px) {
+        display: none;
+      }
+    }
+
   }
 
   .course-sidebar {
@@ -342,27 +376,7 @@ section.course-info {
           justify-content: space-around;
           width: 100%;
           a.register, a.inquire, a.add-to-cart {
-            @include box-sizing(border-box);
-            border-radius: 3px;
-            font: normal 1.2rem/1.6rem $sans-serif;
-            display: block;
-            flex-basis: 45%;
-            align-items: baseline;
-            box-shadow: 0 2px 1px 0 #0a4a67;
-            background: #126f9a;
-            color: #fff;
-            border: none;
-            padding: 10px 20px;
-            text-align: center;
-            text-shadow: none;
-            font-weight: 500;
-            letter-spacing: 0;
-            transition: color 0.25s ease-in-out, background 0.25s ease-in-out, box-shadow 0.25s ease-in-out;
-            margin: 0px ($baseline * 0.25) ($baseline * 0.5);
-            min-width: 150px;
-            &:hover {
-              background: #1790c7;
-            }
+            @include inquire-now-blue-button;
           }
         }
 

--- a/lms/static/sass/_pearsonx.scss
+++ b/lms/static/sass/_pearsonx.scss
@@ -363,7 +363,7 @@ section.course-info {
           }
         }
 
-        > a.find-courses, a.register, a.add-to-cart, a.inquire {
+        a.register, a.add-to-cart, a.inquire {
           @include box-sizing(border-box);
           border-radius: 3px;
           display: block;

--- a/lms/static/sass/_pearsonx.scss
+++ b/lms/static/sass/_pearsonx.scss
@@ -342,6 +342,9 @@ section.course-info {
           justify-content: space-around;
           width: 100%;
           a.register, a.inquire, a.add-to-cart {
+            @include box-sizing(border-box);
+            border-radius: 3px;
+            font: normal 1.2rem/1.6rem $sans-serif;
             display: block;
             flex-basis: 45%;
             align-items: baseline;
@@ -360,20 +363,6 @@ section.course-info {
             &:hover {
               background: #1790c7;
             }
-          }
-        }
-
-        a.register, a.add-to-cart, a.inquire {
-          @include box-sizing(border-box);
-          border-radius: 3px;
-          display: block;
-          font: normal 1.2rem/1.6rem $sans-serif;
-          letter-spacing: 1px;
-          padding: ($baseline/2) 0;
-          text-align: center;
-
-          span {
-            display: inline-block;
           }
         }
 

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -14,7 +14,7 @@ from six.moves.urllib.parse import quote
 %>
 ##
 ## What changed in relation to the upstream template
-## -------------------------------------------------      As of December 2017
+## -------------------------------------------------      As of February 2018
 ##
 ## - Added Coursetalk widget JS
 ## - Removed div.table (only tag, not content) in div.intro-inner-wrapper
@@ -28,6 +28,7 @@ from six.moves.urllib.parse import quote
 ## - Indented code for blocks about course effort and others
 ## - Removed "course reviews tool"
 ## - Added Coursetalk widget
+## - div.details expanded to add an extra "Enquire now" button before the course description (only on small screen)
 ##
 ## ##### ol.important-dates: #####
 ## - In upstream, the shown blocks were: course number, classes start, classes end, estimated effort, course length, course price, prerequisites, requirements
@@ -44,9 +45,10 @@ from six.moves.urllib.parse import quote
 ## ##### section.course-info: #####
 ## - Upstream's contains:  header, div.container>div.details, div.course-sidebar>div.course-summary
 ## - Ours contains: div#contacted-message, header, div.container>div.details, div.course-sidebar>div.course-summary
-
-## ##### Some things that didn't change despite appearing in different positions #####
-## - "View about page in studio" is, in both templates, after closing <header>, and it's inside div.container>div.details
+##
+## ##### div.details: #####
+## - Upstream's contains: .studio-view, .inner-wrapper (with "overview")
+## - Ours contains: .studio-view, a.inquire, .inner-wrapper (with "overview")
 
 
 <%inherit file="course_about.html" />
@@ -333,6 +335,42 @@ ${inquire_url}\
         </a>
         % endif
 
+</%block>
+
+<%block name="course_about_details">
+  <div class="details">
+    % if staff_access and studio_url is not None:
+    <div class="wrap-instructor-info studio-view">
+      <a class="instructor-info-action" href="${studio_url}">${_("View About Page in studio")}</a>
+    </div>
+    % endif
+
+    ## Second "Enquire now" button above the course description (only visible in small screen)
+    ## These conditionals follow the same logic as the main "Enquire now" button (show only to anonymous, etc.)
+    ## It's better to keep it identical to that logic, and minimize optimizations. Refactoring it (e.g. grouping conditions with not(…) and not(…) …) makes it more complex and needs to be compressed in one line.
+    ## mako doesn't seem to support an empty body, therefore an HTML comment is placed in the conditions where we don't show the button.
+    % if user.is_authenticated() and registered:
+      <!-- Enquire now -->
+    % elif in_cart:
+      <!-- Enquire now -->
+    % elif is_course_full:
+      <!-- Enquire now -->
+    % elif invitation_only and not can_enroll:
+      <!-- Enquire now -->
+    % elif not is_shib_course and not can_enroll:
+      <!-- Enquire now -->
+    % elif can_add_course_to_cart:
+      <!-- Enquire now -->
+    % else:
+       <a href="${get_inquire_url(course)}" class="inquire">
+         ${_("Enquire Now")}
+       </a>
+    % endif
+
+    <div class="inner-wrapper">
+      ${get_course_about_section(request, course, "overview")}
+    </div>
+  </div>
 </%block>
 
 ${HTML(parent.body())}

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -51,6 +51,17 @@ from six.moves.urllib.parse import quote
 
 <%inherit file="course_about.html" />
 
+<%def name="get_inquire_url(course)">\
+<%
+  inquire_url = '/contact'
+  inquire_url += '#00N61000002EYUJ={}'.format(quote(course.display_name_with_default_escaped))
+  inquire_url += '&retURL={}'.format(quote(request.build_absolute_uri(request.path) + '#contacted'))
+  if not course.start_date_is_still_default:
+    inquire_url += '&00N61000002L8on={}'.format(quote(course.start.strftime('%B %Y')))
+%>\
+${inquire_url}\
+</%def>
+
 <%block name="js_extra">
   ## CourseTalk widget js script
   % if show_coursetalk_widget:
@@ -184,15 +195,9 @@ from six.moves.urllib.parse import quote
               ${_("Enroll Now")}
             </a>
             % endif
-            <%
-              inquire_url = '/contact'
-              inquire_url += '#00N61000002EYUJ={}'.format(quote(course.display_name_with_default_escaped))
-              inquire_url += '&retURL={}'.format(quote(request.build_absolute_uri(request.path) + '#contacted'))
-              if not course.start_date_is_still_default:
-                inquire_url += '&00N61000002L8on={}'.format(quote(course.start.strftime('%B %Y')))
-            %>
+
             ## The preferred spelling is Enquire. PEAR-48
-            <a href="${inquire_url}" class="inquire">
+            <a href="${get_inquire_url(course)}" class="inquire">
               ${_("Enquire Now")}
             </a>
           </div>


### PR DESCRIPTION
This adds a 2nd „Enquire now“ button, only for small screens, before the course description.

Note that several changes had to be done to achieve this:
- add a block to the platform. https://github.com/open-craft/edx-platform/pull/114
- move the code to generate the enquiry URL into a function (a mako block), to avoid duplicate code
- clean some SASS styles that weren't being applied because they were redefined. Merge SCSS
- create a SASS mixin to be able to use the same button style for buttons in different places 
- update documentation about the differences between upstream and this theme

Other concerns:
- the original „Enroll now“ button in the sandbox shows a strange behaviour when you hover the top part: it blinks (fades in and out). It's due to a remnant of the social icons above. It doesn't happen when the social icons are disabled, which is the case in production.
- the new „enquiry now“ is as wide as the screen allows, but this shouldn't be too wide because it's shown just when the screen is small 

Test instructions in sandbox:
1. Go to https://pearson-test.sandbox.stage.opencraft.hosting/courses/course-v1:testing1+other2+2018_02/about as anonymous. Refresh cache as needed
2. Verify: only the „Enquire now“ button is added, not any other (add to cart, etc.)
3. Verify: the new button only appears in the same conditions as the original button. E.g. if you're logged in you don't see any „Enquire now“ button
4. Verify: the new button and the old button don't appear at the same time
5. Verify URLs of both old and new, compare it with production too
6. Compare the style of all buttons with production
7. Try clicking it
8. Read the code
9. Try in devstack?

Reviewers:
- [ ] @jcdyer
