### PR TITLE
Make header taller on small screens instead of letting its contents float outside

### DIFF
--- a/lms/static/sass/_pearsonx.scss
+++ b/lms/static/sass/_pearsonx.scss
@@ -6,6 +6,16 @@ h2 {
   background-color: $white;
 }
 
+.header-global {
+  height: auto;
+}
+.header-global::after {
+  content: " ";
+  display: block;
+  clear: both;
+  height: 10px;
+}
+
 .find-courses {
   background-color: $white;
   line-height: 140%;


### PR DESCRIPTION
This improves the header behaviour in small screens, by making it cover all its contents instead of letting them escape.

Before (left) and after (right):
![3955_before_after](https://user-images.githubusercontent.com/132703/36664972-f4996d52-1aee-11e8-877c-1984698e32b8.png)

Testing:
1. https://pearson-test.sandbox.stage.opencraft.hosting/courses/course-v1:testing1+other2+2018_02/about, refresh cache if needed
2. verify that the blue line in the header is always below the header contents
3. verify that the course contents are not covered by the header in any screen size
4. check particularly https://pearson-test.sandbox.stage.opencraft.hosting/courses/course-v1:testing1+other2+2018_02/about#contacted because that's we saw a problem: there was blue text over a blue background. The links inside the header shouldn't overlap the message box now.
5. check that the design is otherwise similar to https://courses.pearsonx.com/ except for this change
6. read the code
