### PR TITLE
OC-4050 hide contact picture container on small screens

### DIFF
--- a/lms/static/sass/_pearsonx.scss
+++ b/lms/static/sass/_pearsonx.scss
@@ -213,6 +213,10 @@ h2 {
         width: 100%;
         height: auto;
       }
+      // OC-4050: Hide the picture for small screens to make sure viewport centers on contact form.
+      @media screen and (max-width: 760px) {
+        display: none;
+      }
     }
     .contact-form-container {
       flex-basis: 40%;


### PR DESCRIPTION
Fix the enquire now form to hide the image next to the form on smaller screens.

**Reviewers:**
- [x] @itsjeyd 