### PR TITLE
OC-4061: Fix for thank you banner cut off on mobile

### DIFF
--- a/lms/static/sass/_pearsonx.scss
+++ b/lms/static/sass/_pearsonx.scss
@@ -546,14 +546,16 @@ sure that the inquiry success banner still appears correctly.
   .msg {
     @include clearfix();
     max-width: grid-width(12);
-    min-width: 760px;
+    min-width: auto;
     width: flex-grid(12);
     margin: 0 auto;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
   }
 
   .msg-content,
   .msg-icon {
-    display: inline-block;
     vertical-align: middle;
   }
 
@@ -659,9 +661,6 @@ sure that the inquiry success banner still appears correctly.
     .msg-icon {
       font-size: 2.5em;
       padding: 20px;
-    }
-    .msg-content {
-      max-width: 80%;
     }
   }
 


### PR DESCRIPTION
Fix for thank you banner cut off on mobile.

JIRA tickets: OC-4061

Dependencies: None

Screenshots:

On the left old version (without fix) to the right page with fix:

<img width="787" alt="with_fix" src="https://user-images.githubusercontent.com/1637193/37046971-6740e060-2148-11e8-9b79-f96edd7ac010.png">

Sandbox URL: TBD

Merge deadline: None

Testing instructions:

Check whether the thank you banner text doesn't cut off on mobile size.

Reviewers

[Daniel]