### PR TITLE
Pass "course code" and "institution (hidden)" course fields to enquire form

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -56,10 +56,19 @@ from six.moves.urllib.parse import quote
 <%def name="get_inquire_url(course)">\
 <%
   inquire_url = '/contact'
-  inquire_url += '#00N61000002EYUJ={}'.format(quote(course.display_name_with_default_escaped))
-  inquire_url += '&retURL={}'.format(quote(request.build_absolute_uri(request.path) + '#contacted'))
+  inquire_url += '#retURL={}'.format(quote(request.build_absolute_uri(request.path) + '#contacted'))
+
   if not course.start_date_is_still_default:
     inquire_url += '&00N61000002L8on={}'.format(quote(course.start.strftime('%B %Y')))
+
+  if course.program_code:
+    inquire_url += '&00N61000002EYUJ={}'.format(quote(course.program_code.encode('utf-8')))
+  else:
+    inquire_url += '&00N61000002EYUJ={}'.format(quote(course.display_name_with_default_escaped))
+
+  if course.institution_hidden:
+    inquire_url += '&00N58000005kuvE={}'.format(quote(course.institution_hidden.encode('utf-8')))
+
 %>\
 ${inquire_url}\
 </%def>

--- a/lms/templates/static_templates/contact.html
+++ b/lms/templates/static_templates/contact.html
@@ -510,11 +510,9 @@
                   <option value="TNE" selected="selected">TNE</option>
                 </select><br>
 
-                Institution (Hidden):<select  id="00N58000005kuvE" name="00N58000005kuvE" title="Institution (Hidden)">
-                <option value="TNE-edX" selected="selected">TNE-edX</option>
-                </select><br>
+                Institution (Hidden):<input  id="00N58000005kuvE" name="00N58000005kuvE" title="Institution (Hidden)"><br>
 
-                Program of Interest:<input  id="00N61000002EYUJ" name="00N61000002EYUJ" title="Program of Interest"><br>
+                Program Code:<input  id="00N61000002EYUJ" name="00N61000002EYUJ" title="Program Code"><br>
 
                 <label for="company">Company</label><input value="TNE" id="company" maxlength="40" name="company" size="20" type="text" /><br>
 


### PR DESCRIPTION
This uses the two new hidden fields added at https://github.com/open-craft/edx-platform/pull/117 in the „Enquire now“ form.

Testing:
1. apply changes from the platform PR and fill in some program codes and institution for some programs
2. Go to the programs listing. Click a program. Click its „enquire now“ button
3. In the form, check the the hidden values have the values specified by the program:
`$("#00N58000005kuvE").val()`
`$("#00N61000002EYUJ").val()`
4. Check that the default values preserve the old behaviour
