### PR TITLE
"invitation_only" links weren't working because of JS click event

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -20,7 +20,7 @@ from openedx.core.lib.courses import course_image_url
 <%block name="js_extra">
   <script type="text/javascript">
   (function() {
-    $(".register").click(function(event) {
+    $(".register[href='#']").click(function(event) {
       $("#class_enroll_form").submit();
       event.preventDefault();
     });


### PR DESCRIPTION
Altered JQuery selector to override click event only for "register" links without actual links attached.

**JIRA issue** OC-4145

**Testing instructions**
1. Create a course with Advanced Settings > "Invitation only: false" .
1. View the course about page in the LMS without authenticating.
1. Ensure that you can click on the "Purchase a Course or Library Subscription" button, and it redirects you to https://www.cloudera.com/more/training/ondemand-training.html

**Reviewer**
- [ ] @smarnach CC @bradenmacdonald 