### PR TITLE
Improve contact form logic and remove old CSS

### DIFF
--- a/lms/static/sass/_pearsonx.scss
+++ b/lms/static/sass/_pearsonx.scss
@@ -37,12 +37,12 @@ h2 {
     margin-left: auto;
     margin-right: auto;
     background: $white;
-
+  
     .hero-container {
       display: flex;
       flex-wrap: wrap;
     }
-
+    
     .hero-image {
       background-image: $homepage-bg-image;
       background-position: left 50% bottom 33%;
@@ -691,12 +691,3 @@ sure that the inquiry success banner still appears correctly.
   }
 }
 
-/*
-Below is a quick fix of Sign-up button
-which appeared on the main page
-likely due to some Facebook Pixel/Google Tag manager
-issue.
-*/
-body > #contact-submit-button {
- display: none;
-}

--- a/lms/templates/static_templates/contact.html
+++ b/lms/templates/static_templates/contact.html
@@ -534,6 +534,9 @@
                 Medium:<input  id="00N5800000DLC7w" maxlength="255" name="00N5800000DLC7w" size="20" type="text" /><br>
  
                 Term (Keyword):<input  id="00N5800000DLC7x" maxlength="255" name="00N5800000DLC7x" size="20" type="text" /><br>
+
+                ## Uncomment this to redirect to a SalesForce page which shows the submitted variables. Note that the form will still be sent (if you want to disable sending it, change the "oid" parameter above)
+                ## <input type="hidden" name="debug" value="1">
  
             </div>
             <div id="required-fields-error-message" class="error-message">

--- a/lms/templates/static_templates/contact.html
+++ b/lms/templates/static_templates/contact.html
@@ -577,26 +577,30 @@
                 el.prop("disabled", !affirms);
             });
             $("form#contact-form").submit(function (event){
-                var errors = false;
+                // Validate required
+                var required_fields_ok = true;
                 $('form#contact-form').children("input, select").each(function(i, el){
                     if(!el.value){
-                        $("#required-fields-error-message").show();
-                        errors = true;
-                        event.preventDefault();
-                    }else{
-                        $("#required-fields-error-message").hide();
+                        required_fields_ok = false;
                     }
                 });
-                emailVal = $("#email").val();
+                if(!required_fields_ok) {
+                    $("#required-fields-error-message").show();
+                }else{
+                    $("#required-fields-error-message").hide();
+                }
+
+                // Validate values
+                var field_values_ok = true;
+                var emailVal = $("#email").val();
                 if(!(emailVal.split("@").length == 2)){
                     $("#invalid-email-error-message").show();
-                    errors = true;
-                    event.preventDefault();
+                    field_values_ok = false;
                 }else{
                     $("#invalid-email-error-message").hide();
                 }
 
-                if(!errors) {
+                if(required_fields_ok && field_values_ok) {
                     // Form being submitted
 
                     // Disable clicking the submit button again, to avoid double form submissions
@@ -610,6 +614,8 @@
                     // Show spinner
                     el = $("#contact-submit-button .icon.fa.fa-spinner");
                     el.css("display", "inline-block");
+                } else {
+                    event.preventDefault();
                 }
 
             });


### PR DESCRIPTION
- Fix contact form logic in which a valid form field will make the entire form valid, if the valid one appears after the invalid one.
- Revert old CSS code that was used to hide a „Sign up“ button and that isn't needed.
- Also includes a commented debug setting for the SalesForce page, from https://help.salesforce.com/articleView?id=setting_up_web-to-lead.htm&type=5

Test instructions.
1. At https://pearson-test.sandbox.stage.opencraft.hosting/ (anonymously) check that there's no strange „sign in“ button (as was happening in the screenshot at https://tasks.opencraft.com/browse/PEAR-42)
2. But check that at https://pearson-test.sandbox.stage.opencraft.hosting/courses/course-v1:testing1+other2+2018_02/about the „Sign in“ button is still there (same as https://courses.pearsonx.com/contact)
3. Try the form at https://pearson-test.sandbox.stage.opencraft.hosting/contact#retURL=https%3A//pearson-test.sandbox.stage.opencraft.hosting/courses/course-v1%3Atesting1%2Bother2%2B2018_02/about%23contacted&00N61000002EYUJ=Some%20other%20course&00N58000005kuvE=TNE-edX, e.g. leave all fields empty, submit, see the error „all fields required“, then choose the last field (country of residence) and submit again, it should still say „all fields required“ (this case doesn't work at https://courses.pearsonx.com/contact)
4. Try submitting the form (the `oid` parameter is disabled in the HTML so you won't be sending it to their server, so you can test)

