### PR TITLE
Add a timestamp field to the contact form

### DIFF
--- a/lms/templates/static_templates/contact.html
+++ b/lms/templates/static_templates/contact.html
@@ -535,6 +535,10 @@
  
                 Term (Keyword):<input  id="00N5800000DLC7x" maxlength="255" name="00N5800000DLC7x" size="20" type="text" /><br>
 
+                ## This field was enabled in April 2018 to debug double submissions and it is set to a timestamp. Pearson doesn't use the "profession" field in Salesforce and they are fine with receiving numbers here.
+                <!-- actually used to store a timestamp -->
+                Profession: <input id="00N58000003di7f" maxlength="50" name="00N58000003di7f" size="20" type="text" /><br>
+
                 ## Uncomment this to redirect to a SalesForce page which shows the submitted variables. Note that the form will still be sent (if you want to disable sending it, change the "oid" parameter above)
                 ## <input type="hidden" name="debug" value="1">
  
@@ -580,6 +584,10 @@
                 el.prop("disabled", !affirms);
             });
             $("form#contact-form").submit(function (event){
+
+                // Store a random number and a timestamp, to help detect duplicate submissions. We use the Profession field
+                $("#00N58000003di7f").val( Date.now() + "-" + Math.floor((Math.random() * 100000) + 1) );
+
                 // Validate required
                 var required_fields_ok = true;
                 $('form#contact-form').children("input, select").each(function(i, el){


### PR DESCRIPTION
To debug double submissions, we're sending a timestamp and a random number in the contact form. The field Profession was suggested by them because it's unused.

Testing instructions.
1. https://pearson-test.sandbox.stage.opencraft.hosting/courses/course-v1:testing1+other2+2018_02/about and click „enquire now“
2. check in the HTML that the "oid" parameter has a nonsense value instead of their ID. Then you'll be able to submit the form without altering their DB. The form also has debug=1 so it will send you to a debug page
3. fill the form and submit it, it will go to a debug page
4. check the contents of the field 00N58000003di7f, it should have XXXXXXXX-YYYYY, where XXXXXXX is a timestamp (in ~~ms) and YYYYY a random number
5. Check that the code is in the right place (e.g. if some clicked the button twice, it would send different results

Reviewers: one of:
- @ciuin (if available)
- @bradenmacdonald 
- or TBD
