### PR TITLE
Add "campaign" parameter

### DIFF
--- a/lms/templates/static_templates/contact.html
+++ b/lms/templates/static_templates/contact.html
@@ -535,6 +535,8 @@
  
                 Term (Keyword):<input  id="00N5800000DLC7x" maxlength="255" name="00N5800000DLC7x" size="20" type="text" /><br>
 
+                Campaign (Source):<input  id="CampaignSource" maxlength="255" name="00N5800000DYqcL" size="20" type="text" /><br>
+
                 ## Uncomment this to redirect to a SalesForce page which shows the submitted variables. Note that the form will still be sent (if you want to disable sending it, change the "oid" parameter above)
                 ## <input type="hidden" name="debug" value="1">
  


### PR DESCRIPTION
This adds a new marketing field „campaign (source)“ which comes from a cookie set by the marketing middleware.

**JIRA tickets**: None
**Discussions**: None
**Dependencies**: yes, merge https://gitlab.com/opencraft/client/pearsonx-marketing-middleware/merge_requests/3 first
**Screenshots**: None
**Sandbox URL**: None
**Merge deadline**: None

**Testing instructions**:
1. Go to https://pearson-test.sandbox.stage.opencraft.hosting/?leadsource=source1&campaign=email1, note that the URL has some parameters. You'll see the normal page, but the parameters will be set in a cookie
2. Go to https://pearson-test.sandbox.stage.opencraft.hosting/contact#00N61000002EYUJ=Some%20other%20course&retURL=https%3A//pearson-test.sandbox.stage.opencraft.hosting/courses/course-v1%3Atesting1%2Bother2%2B2018_02/about%23contacted
3. Write some phone number
4. Check in the console that `$("#phone").val()` works to get that form field
5. Check that `$("#CampaignSource").val()` works in the same way but gets the content from the first URL
6. Submit the form (look for "oid" parameter in source, check that it's fake so that it doesn't send them real data). You should see a SalesForce debug page (I enabled it in the sandbox) with the `00N5800000DYqcL` parameter set
7. Check that our documentation was updated

**Reviewers**
- [ ] @pomegranited 

**Author concerns**: None
**Settings**: None
