### PR TITLE
Fix register link

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -20,7 +20,7 @@ from openedx.core.lib.courses import course_image_url
 <%block name="js_extra">
   <script type="text/javascript">
   (function() {
-    $(".register[href='#']").click(function(event) {
+    $(".register[href='#'], .register[href='']").click(function(event) {
       $("#class_enroll_form").submit();
       event.preventDefault();
     });


### PR DESCRIPTION
The fix applied for https://github.com/open-craft/edx-theme/pull/39 breaks the "course enrol" links when e-commerce is enabled, because the [course enrol link is often empty](https://github.com/edx/edx-platform/blob/open-release/ginkgo.1/lms/djangoapps/courseware/views/views.py#L750).

**Testing instructions**

1. Visit https://cloudera-ecommerce.sandbox.opencraft.hosting/courses
1. Ensure that you can enrol via the [Paid Course](https://cloudera-ecommerce.sandbox.opencraft.hosting/courses/course-v1:Cloudera+ExampleX+2018_1/about) and [DemoX course](https://cloudera-ecommerce.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/about) links 
1. Ensure that the [Invitation Only](https://cloudera-ecommerce.sandbox.opencraft.hosting/courses/course-v1:Cloudera+InviteX+2018_2/about) course redirects to [Cloudera's OnDemand Training](https://www.cloudera.com/more/training/ondemand-training.html) site.

**Reviewer**
- [x] @clemente 