### PR TITLE
Change Terms of Service link

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -47,7 +47,7 @@
       </ul>
       <ul class="cloudera-footer-bottom-right-links">
         <li>
-          <a href="http://www.cloudera.com/legal/terms-and-conditions.html">Terms & Conditions</a>
+          <a href="https://www.cloudera.com/legal/commercial-terms-and-conditions/cloudera-training-terms.html">Terms &amp; Conditions</a>
         </li>
         <li>
           <a href="http://www.cloudera.com/legal/policies.html">Policies</a>


### PR DESCRIPTION
Updated the Terms & Services link used in the Cloudera footer.

**Testing instructions**

Already deployed to https://ondemand.cloudera.com

1. Check the Terms & Services link in the footer
1. Check the Terms & Services link on the [/register](https://ondemand.cloudera.com) page.
   Note: due to aggressive redirect caching, you may need to clear your cache to see the new URL.

**Reviewers**
- [ ] @mtyaka 