### PR TITLE
OC-4423: Cloudera: Add link to Vimeo tour to home page

### DIFF
--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -36,6 +36,7 @@ from openedx.core.djangolib.markup import HTML, Text
             <h2>Training to meet your needs</h2>
             <p>Cloudera OnDemand provides a video training option where you can learn from senior instructors—who deliver our most popular courses in a virtual classroom setting—without incurring travel costs or time away from the office.</p>
             <p>Cloudera OnDemand training is designed to facilitate individual, or enterprise-wide, training to help accelerate the ROI of Cloudera deployments. Get access to all of Cloudera’s training courses in a single package, or choose the course(s) specific to you needs.</p>
+	    <p>Curious about what Cloudera OnDemand offers and how it works? <a href="https://vimeopro.com/clouderauniversity/cloudera-ondemand-tour">Watch this video tour!</a></p>
             <a href="/login" class="cloudera-custom-button">Sign in</a>
           </div>
         </div>


### PR DESCRIPTION
Cloudera would like a link to the tour on the home page of the site (ondemand.cloudera.com). The link should point to https://vimeopro.com/clouderauniversity/cloudera-ondemand-tou

**Dependencies**: None

**Screenshots**: attached to the ticket

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None
**Testing instructions**:

1. Look at the main page, it contains the link

**Reviewers**
- [ ] pomegranited
