### PR TITLE
Add upstream templates for weekly highlight emails.

### DIFF
--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.html
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.html
@@ -1,0 +1,40 @@
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+{% load i18n %}
+
+{% block preview_text %}
+    {% blocktrans trimmed %}
+        Welcome to week {{ week_num }} of {{ course_name }}!
+    {% endblocktrans %}
+{% endblock %}
+
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <p>
+                {% blocktrans trimmed %}
+                    We hope you're enjoying <strong>{{ course_name }}</strong>!
+                    We want to let you know what you can look forward to in week {{ week_num }}:
+                {% endblocktrans %}
+                <ul>
+                    {% for highlight in week_highlights %}
+                        <li>{{ highlight }}</li>
+                    {% endfor %}
+                </ul>
+            </p>
+            <p>
+                {% blocktrans trimmed %}
+                    With self-paced courses, you learn on your own schedule.
+                    We encourage you to spend time with the course each week.
+                    Your focused attention will pay off in the end!
+                {% endblocktrans %}
+            </p>
+
+            {% trans "Resume your course now" as course_cta_text %}
+            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text%}
+
+            {% include "ace_common/edx_ace/common/upsell_cta.html"%}
+        </td>
+    </tr>
+</table>
+{% endblock %}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.txt
@@ -1,0 +1,18 @@
+{% autoescape off %}
+{% load i18n %}
+
+{% blocktrans trimmed %}
+We hope you're enjoying {{ course_name }}!
+We want to let you know what you can look forward to in week {{ week_num }}:
+{% endblocktrans %}
+
+{% for highlight in week_highlights %}
+  * {{ highlight }}
+{% endfor %}
+
+{% blocktrans trimmed %}
+With self-paced courses, you learn on your own schedule. We encourage you to spend time with the course each week.
+Your focused attention will pay off in the end!
+{% endblocktrans %}
+{% include "ace_common/edx_ace/common/upsell_cta.txt"%}
+{% endautoescape %}


### PR DESCRIPTION
This adds upstream template for weekly highlight emails, which will be later on used to add support to opt out of highlight emails.
Reviewers: @pomegranited 