### PR TITLE
Change template text from 'week' to 'section'

### DIFF
--- a/lms/templates/schedules/edx_ace/courseupdate/email/body.html
+++ b/lms/templates/schedules/edx_ace/courseupdate/email/body.html
@@ -3,7 +3,7 @@
 
 {% block preview_text %}
     {% blocktrans trimmed %}
-        Welcome to week {{ week_num }} of {{ course_name }}!
+        Welcome to Section {{ week_num }} of {{ course_name }}!
     {% endblocktrans %}
 {% endblock %}
 
@@ -14,7 +14,7 @@
             <p>
                 {% blocktrans trimmed %}
                     We hope you're enjoying <strong>{{ course_name }}</strong>!
-                    We want to let you know what you can look forward to in week {{ week_num }}:
+                    We want to let you know what you can look forward to in Section {{ week_num }}:
                 {% endblocktrans %}
                 <ul>
                     {% for highlight in week_highlights %}

--- a/lms/templates/schedules/edx_ace/courseupdate/email/subject.txt
+++ b/lms/templates/schedules/edx_ace/courseupdate/email/subject.txt
@@ -1,5 +1,5 @@
 {% autoescape off %}
 {% load i18n %}
 
-{% blocktrans %}Welcome to week {{ week_num }} {% endblocktrans %}
+{% blocktrans %}Welcome to Section {{ week_num }} {% endblocktrans %}
 {% endautoescape %}


### PR DESCRIPTION
This PR modifies the weekly highlight email template from "We want to let you know what you can look forward to in week 1:" to "We want to let you know what you can look forward to in section 1:"

Before the template change:

![before-template-change](https://user-images.githubusercontent.com/13742492/48657952-a1ac0c80-ea5f-11e8-860c-4ea3fedf0b29.png)


After the template change:

![after-template-change](https://user-images.githubusercontent.com/13742492/48657954-b7213680-ea5f-11e8-990c-dc3e12ca7d95.png)

