### PR TITLE
SE-362 Updates subject and email preview for Course Highlights messages

### DIFF
--- a/lms/templates/schedules/edx_ace/courseupdate/email/body.html
+++ b/lms/templates/schedules/edx_ace/courseupdate/email/body.html
@@ -3,7 +3,7 @@
 
 {% block preview_text %}
     {% blocktrans trimmed %}
-        Welcome to Section {{ week_num }} of {{ course_name }}!
+        Highlights of Section {{ week_num }}, {{ course_name }}!
     {% endblocktrans %}
 {% endblock %}
 

--- a/lms/templates/schedules/edx_ace/courseupdate/email/subject.txt
+++ b/lms/templates/schedules/edx_ace/courseupdate/email/subject.txt
@@ -1,5 +1,5 @@
 {% autoescape off %}
 {% load i18n %}
 
-{% blocktrans %}Welcome to Section {{ week_num }} {% endblocktrans %}
+{% blocktrans %}Welcome to Section {{ week_num }} of {{course_name}}{% endblocktrans %}
 {% endautoescape %}


### PR DESCRIPTION
Minor tweaks to the subject and preview text as requested by the client.

**JIRA tickets**: SE-362

**Sandbox URL**: http://hawthorn-cloudera.opencraft.hosting/

**Testing instructions**:

1. Enroll in a course with scheduled Weekly Highlight messages enabled.
1. In Django Admin, modify the created Schedule object to place your Start Date at 7 days prior to the current date.
1. On the command line, run the `lms send_course_update` management command to send the emails.
1. Check your email and verify the subject/preview text display as expected.

**Reviewers**
- [x] @pkulkark 