### PR TITLE
SE-890 Public Courses: Cloudera theme updates

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -1,12 +1,15 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.utils.translation import pgettext
+from django.urls import reverse
 from courseware.courses import get_course_about_section
 from django.conf import settings
+from six import text_type
 from edxmako.shortcuts import marketing_link
 from openedx.core.djangolib.markup import HTML
 from openedx.core.lib.courses import course_image_url
+from six import string_types
 %>
 
 <%inherit file="../main.html" />
@@ -42,7 +45,7 @@ from openedx.core.lib.courses import course_image_url
 
       $("#add_to_cart_post").click(function(event){
         $.ajax({
-          url: "${reverse('add_course_to_cart', args=[course.id.to_deprecated_string()])}",
+          url: "${reverse('add_course_to_cart', args=[text_type(course.id)])}",
           type: "POST",
           /* Rant: HAD TO USE COMPLETE B/C PROMISE.DONE FOR SOME REASON DOES NOT WORK ON THIS PAGE. */
           complete: add_course_complete_handler
@@ -65,7 +68,7 @@ from openedx.core.lib.courses import course_image_url
       if(xhr.status == 200) {
         location.href = "${reverse('dashboard')}";
       } else if (xhr.status == 403) {
-        location.href = "${reverse('course-specific-register', args=[course.id.to_deprecated_string()])}?course_id=${course.id | u}&enrollment_action=enroll";
+        location.href = "${reverse('course-specific-register', args=[text_type(course.id)])}?course_id=${course.id | u}&enrollment_action=enroll";
       } else if (xhr.status == 400) { //This means the user did not have permission
         $('#register_error').html("${perms_error}").css("display", "block");
       } else {
@@ -105,6 +108,8 @@ from openedx.core.lib.courses import course_image_url
 <%block name="pagetitle">${course.display_name_with_default_escaped}</%block>
 
 <section class="course-info">
+
+  <%block name="course_about_header">
   <header class="course-profile">
     <div class="intro-inner-wrapper">
       <div class="table">
@@ -112,12 +117,13 @@ from openedx.core.lib.courses import course_image_url
         <div class="heading-group">
           <h1>
             ${course.display_name_with_default_escaped}
-            <button type="button">${course.display_org_with_default | h}</button>
           </h1>
+          <br />
+          <span>${course.display_org_with_default | h}</span>
         </div>
 
         <div class="main-cta">
-        %if user.is_authenticated() and registered:
+        %if user.is_authenticated and registered:
           %if show_courseware_link:
             <a href="${course_target}">
           %endif
@@ -148,7 +154,7 @@ from openedx.core.lib.courses import course_image_url
           <span class="register disabled">${_("Enrollment is Closed")}</span>
         %elif can_add_course_to_cart:
           <%
-          if user.is_authenticated():
+          if user.is_authenticated:
             reg_href = "#"
             reg_element_id = "add_to_cart_post"
           else:
@@ -164,6 +170,12 @@ from openedx.core.lib.courses import course_image_url
               .format(course_name=course.display_number_with_default, price=course_price)}
           </a>
           <div id="register_error"></div>
+        %elif allow_anonymous:
+          %if show_courseware_link:
+            <a href="${course_target}">
+            <strong>${_("View Course")}</strong>
+            </a>
+          %endif
         %else:
           <% 
             if ecommerce_checkout:
@@ -200,8 +212,11 @@ from openedx.core.lib.courses import course_image_url
     </div>
       </div>
   </header>
+  </%block>
 
   <div class="container">
+
+    <%block name="course_about_details">
     <div class="details">
       % if staff_access and studio_url is not None:
         <div class="wrap-instructor-info studio-view">
@@ -212,23 +227,25 @@ from openedx.core.lib.courses import course_image_url
       <div class="inner-wrapper">
         ${get_course_about_section(request, course, "overview")}
       </div>
-  </div>
+    </div>
+    </%block>
 
     <div class="course-sidebar">
       <div class="course-summary">
 
         <%include file="course_about_sidebar_header.html" />
 
+        <%block name="course_about_important_dates">
         <ol class="important-dates">
           <li class="important-dates-item"><span class="icon fa fa-info-circle" aria-hidden="true"></span><p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default | h}</span></li>
           % if not course.start_date_is_still_default:
               <%
-                  course_start_date = course.start
+                  course_start_date = course.advertised_start or course.start
               %>
             <li class="important-dates-item">
               <span class="icon fa fa-calendar" aria-hidden="true"></span>
               <p class="important-dates-item-title">${_("Classes Start")}</p>
-              % if isinstance(course_start_date, str):
+              % if isinstance(course_start_date, string_types):
                   <span class="important-dates-item-text start-date">${course_start_date}</span>
               % else:
                   <%
@@ -240,7 +257,7 @@ from openedx.core.lib.courses import course_image_url
           % endif
             ## We plan to ditch end_date (which is not stored in course metadata),
             ## but for backwards compatibility, show about/end_date blob if it exists.
-            % if get_course_about_section(request, course, "end_date") or course.end:
+            % if course.end:
                 <%
                     course_end_date = course.end
                 %>
@@ -248,7 +265,7 @@ from openedx.core.lib.courses import course_image_url
             <li class="important-dates-item">
                 <span class="icon fa fa-calendar" aria-hidden="true"></span>
                 <p class="important-dates-item-title">${_("Classes End")}</p>
-                  % if isinstance(course_end_date, str):
+                  % if isinstance(course_end_date, string_types):
                       <span class="important-dates-item-text final-date">${course_end_date}</span>
                   % else:
                     <%
@@ -289,16 +306,20 @@ from openedx.core.lib.courses import course_image_url
             </p>
           </li>
           % endif
+
           % if get_course_about_section(request, course, "prerequisites"):
             <li class="important-dates-item"><span class="icon fa fa-book" aria-hidden="true"></span><p class="important-dates-item-title">${_("Requirements")}</p><span class="important-dates-item-text prerequisites">${get_course_about_section(request, course, "prerequisites")}</span></li>
           % endif
         </ol>
+        </%block>
     </div>
 
+      <%block name="course_about_reviews_tool">
       ## Course reviews tool
       % if reviews_fragment_view:
        ${HTML(reviews_fragment_view.body_html())}
       % endif
+      </%block>
 
       ## For now, ocw links are the only thing that goes in additional resources
       % if get_course_about_section(request, course, "ocw_links"):
@@ -315,6 +336,13 @@ from openedx.core.lib.courses import course_image_url
     </div>
       %endif
 
+    % if sidebar_html_enabled:
+      % if get_course_about_section(request, course, "about_sidebar_html"):
+        <section class="about-sidebar-html">
+          ${get_course_about_section(request, course, "about_sidebar_html")}
+        </section>
+      % endif
+    %endif
   </div>
 
   </div>
@@ -327,12 +355,12 @@ from openedx.core.lib.courses import course_image_url
   <div style="display: none;">
     <form id="class_enroll_form" method="post" data-remote="true" action="${reverse('change_enrollment')}">
       <fieldset class="enroll_fieldset">
-        <legend class="sr">${_("Enroll")}</legend>
+        <legend class="sr">${pgettext("self","Enroll")}</legend>
         <input name="course_id" type="hidden" value="${course.id | h}">
         <input name="enrollment_action" type="hidden" value="enroll">
       </fieldset>
       <div class="submit">
-        <input name="submit" type="submit" value="${_('enroll')}">
+        <input name="submit" type="submit" value="${pgettext('self','enroll')}">
       </div>
     </form>
   </div>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -125,13 +125,13 @@ from six import string_types
         <div class="main-cta">
         %if user.is_authenticated and registered:
           %if show_courseware_link:
-            <a href="${course_target}">
+            <a class="register" href="${course_target}">
           %endif
 
           <span class="register disabled">${_("You are enrolled in this course")}</span>
 
           %if show_courseware_link:
-            <strong>${_("View Course")}</strong>
+            ${_("View Course")}
             </a>
           %endif
 
@@ -172,8 +172,8 @@ from six import string_types
           <div id="register_error"></div>
         %elif allow_anonymous:
           %if show_courseware_link:
-            <a href="${course_target}">
-            <strong>${_("View Course")}</strong>
+            <a class="register" href="${course_target}">
+            ${_("View Course")}
             </a>
           %endif
         %else:


### PR DESCRIPTION
Updates the theme templates affected by the Public Courses feature, backported with https://github.com/open-craft/edx-platform/pull/158

Specifically:
* Show a "View Course" button for public courses, instead of the Enroll button.

**JIRA tickets**: SE-890

**Screenshots**: TBD

*Public course*
![Public course](https://user-images.githubusercontent.com/7556571/54402717-fb29fc80-471c-11e9-8bf2-73737703891a.png)

*Invite-only course*
![Public outline invite only](https://user-images.githubusercontent.com/7556571/54402432-db460900-471b-11e9-9270-c8614cd98466.png)

**Sandbox URL**:

* LMS: https://pr158-cloudera.sandbox.opencraft.hosting
* Studio: https://studio.pr158-cloudera.sandbox.opencraft.hosting

**Testing instructions**:

Compare the sandbox courses with similar courses on Cloudera OnDemand, as an anonymous user on both:
1. View the [Public Course about page](https://pr158-cloudera.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+Public+2019_1/about) on the sandbox.
   Compare with the live public course about page for [Preparing for Cloudera Certification ](https://ondemand.cloudera.com/courses/course-v1:Cloudera+CertPrep+101/about), and ensure that the only difference is that the live site shows an "Enroll" button, where our sandbox shows a "View Course" button which leads to the course outline.
1. View the [Public Outline (invite only)](https://pr158-cloudera.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+PublicOutline+2019_1/about) course on the sandbox, and ensure that it looks like the live public outline invite only course, [Developer Training for Apache Spark and Hadoop](https://ondemand.cloudera.com/courses/course-v1:Cloudera+DevSH+180515/about).
  Specifically, ensure that the "Purchase a course or library subscription" button remains, and it leads to the [custom Cloudera purchase page](https://www.cloudera.com/more/training/ondemand-training.html).
1. View the [edX Demo about page](https://pr158-cloudera.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/about) on the sandbox, and ensure that it still shows an "Enroll" button.
   There's no equivalent course on the live site to compare this too, since there aren't any private, non-invite-only courses left on Cloudera OnDemand.  (All of theirs are either public-outline/invite-only or public.)

**Author Notes & Concerns**:

1. Commit 1e33429 comes from following [these instructions in the README](https://github.com/open-craft/edx-theme/tree/1e334297c969556bbd711ec41b14bb0080dd96f5#custom-templates):
   ```
   git checkout cloudera-upstream-templates
   git -C ../../edx-platform/ show opencraft-release/hawthorn.1-cloudera:lms/templates/courseware/course_about.html > lms/templates/courseware/course_about.html
   git commit -am "Updated upstream version of course_about.html"
   git push
   
   git checkout jill/public-courses
   git reset --hard origin/cloudera
   git merge cloudera-upstream-templates
   ```
1. Commit 8ad9400 adjusts the View Course links so they look like the other Cloudera-themed buttons on the Course About page.  Another approach would have been to adjust the scss, but that didn't look as straightforward to do.

**Reviewers**
- [ ] @pkulkark ?