### PR TITLE
SE-890 Fix for Public Course About page

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -124,15 +124,10 @@ from six import string_types
 
         <div class="main-cta">
         %if user.is_authenticated and registered:
-          %if show_courseware_link:
-            <a class="register" href="${course_target}">
-          %endif
-
-          <span class="register disabled">${_("You are enrolled in this course")}</span>
+          <span>${_("You are enrolled in this course")}<br/><br/></span>
 
           %if show_courseware_link:
-            ${_("View Course")}
-            </a>
+            <a class="register" href="${course_target}">${_("View Course")}</a>
           %endif
 
         %elif in_cart:


### PR DESCRIPTION
For users who are enrolled in Public Courses, the text shown on the about page was nested strangely inside the View Course button.

This PR addresses that issue by adjusting the theme's custom course about template.

**JIRA** SE-890

**Screenshots**
*broken about page*
![Screen Shot 2019-03-17 at 11 53 30 am](https://user-images.githubusercontent.com/7556571/54483923-d748f100-48ab-11e9-92f2-4d56c9c772ec.png)

*fixed about page*
![Screen Shot 2019-03-17 at 11 57 56 am](https://user-images.githubusercontent.com/7556571/54483928-f34c9280-48ab-11e9-8736-4157a94bccdb.png)

**Testing Instructions**

An logged in user on the sandbox:
1. Enroll in the [Public Course](https://pr158-cloudera.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+Public+2019_1/about).  Ensure that the "You are enrolled in this course" text displays clearly above the "View Course" button, which takes you to the the course outline.
1.Repeat the above for the [Public Outline (invite only)](https://pr158-cloudera.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+PublicOutline+2019_1/about), and  the [edX Demo course](https://pr158-cloudera.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/about).

**Author Notes & Concerns**

1. Since this was a production issue, I went ahead and merged and deployed it.
